### PR TITLE
fixed issue where the 'Replace Logo' option did not show up on rare a…

### DIFF
--- a/dist/app/customiser.css
+++ b/dist/app/customiser.css
@@ -44,7 +44,7 @@ body[main] .sub:has(#iconanim),
 .optcont:has(.opt > input[type="checkbox"]#showhiddenicon:not(:checked)) > .opt:has(.img#hiddenicon),
 .optcont:has(.opt > input[type="checkbox"]#usecustompos:not(:checked)) > .opt#posbtns,
 .optcont:has(.opt > .img#logo[novalue]) > .opt:has(input#replacelogo),
-.optcont:has(.opt > .img[id="decoration1"][novalue]) > .opt:has(input#replacelogo) {
+.optcont:has(.opt > .img[id="decoration1"][novalue]):has(.opt > .img[id="decoration2"][novalue]):has(.opt > .img[id="decoration3"][novalue]) > .opt:has(input#replacelogo) {
     display: none;
 }
 


### PR DESCRIPTION
The old CSS removed the Replace Logo option from the Rare and 100% customization screen, no matter what notification preset you chose. This fixes that issue and allows people to also replace the logo on those types of notifications