### PR TITLE
Feat: Add Native Screenshot Only mode and fix overlay screenshot bug

### DIFF
--- a/dist/app/settings.css
+++ b/dist/app/settings.css
@@ -190,7 +190,8 @@ body:not([trophymode]) .wrapper#webhooktypeswrapper > .opt:has(#webhooksemi),
     display: none;
 }
 
-.opt:has(#ssenabled:not(:checked)) ~ .opt:has(#ovpos,#ovmatch,.lbl#sselemselectorlbl,#ovpath,#imgpath,#ssdelay,#sspreview),
+.opt:has(#ssenabled:not(:checked)) ~ .opt:has(#ovpos,#ovmatch,.lbl#sselemselectorlbl,#ovpath,#imgpath,#sspreview):not([screenshot_only]),
+.opt:has(#ssenabled:not(:checked)) ~ .opt:has(#ssdelay):not([screenshot_only]),
 .opt:has(#ssenabled:not(:checked)) ~ .wrapper[overlay]:has(> .wrapper[overlay]):has(#ovx,#ovy) {
     display: none !important;
 }
@@ -295,7 +296,8 @@ dialog[menu]:has(#settingscontent) *[notifyimg]:not(.synclbl) {
 }
 
 dialog[menu]:has(#settingscontent) .optcont:has(select#screenshots > option[value="overlay"]:checked) *[overlay]:not(.synclbl),
-dialog[menu]:has(#settingscontent) .optcont:has(select#screenshots > option[value="notifyimg"]:checked) *[notifyimg]:not(.synclbl) {
+dialog[menu]:has(#settingscontent) .optcont:has(select#screenshots > option[value="notifyimg"]:checked) *[notifyimg]:not(.synclbl),
+dialog[menu]:has(#settingscontent) .optcont:has(select#screenshots > option[value="screenshot_only"]:checked) *[screenshot_only]:not(.synclbl) {
     display: grid;
 }
 

--- a/dist/app/settings.html
+++ b/dist/app/settings.html
@@ -200,20 +200,21 @@
                         <option value="off"></option>
                         <option value="overlay"></option>
                         <option value="notifyimg"></option>
+                        <option value="screenshot_only">Native Screenshot Only</option>
                     </select>
                 </div>
-                <div class="wrapper opt" overlay star>
+                <div class="wrapper opt" overlay screenshot_only star>
                     <span></span>
                     <select name="ssmode" id="ssmode">
                         <option value="screen"></option>
                         <option value="window"></option>
                     </select>
                 </div>
-                <div class="wrapper opt" overlay>
+                <div class="wrapper opt" overlay screenshot_only>
                     <span class="lbl"></span>
                     <select name="monitors" id="monitors"></select>
                 </div>
-                <div class="wrapper opt" overlay>
+                <div class="wrapper opt" overlay screenshot_only>
                     <span></span>
                     <input type="checkbox" id="hdrmode">
                 </div>
@@ -253,7 +254,7 @@
                         <input unit="px" type="range" min="-100" max="100" step="5" id="ovy">
                     </div>
                 </div>
-                <div class="wrapper opt" overlay>
+                <div class="wrapper opt" overlay screenshot_only>
                     <span class="lbl"></span>
                     <button class="optbtn" id="ovpath" dir>
                         <span></span>
@@ -265,7 +266,7 @@
                         <span></span>
                     </button>
                 </div>
-                <div class="wrapper opt" overlay>
+                <div class="wrapper opt" overlay screenshot_only>
                     <span class="lbl"></span>
                     <input unit="seconds" type="range" min="0" max="10" step="0.5" id="ssdelay">
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,18 +33,6 @@
                 "typescript": "^5.2.2"
             }
         },
-        "deps/appinfo.vdf": {
-            "name": "appinfovdf",
-            "version": "0.0.1",
-            "extraneous": true,
-            "license": "MIT",
-            "devDependencies": {
-                "@napi-rs/cli": "^2.18.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "deps/sanhelper.rs": {
             "name": "sanhelperrs",
             "version": "0.0.4",
@@ -54,6 +42,21 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "deps/sanhelper.rs/node_modules/@napi-rs/cli": {
+            "version": "2.18.4",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "napi": "scripts/index.js"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
             }
         },
         "deps/steamworks.js": {
@@ -72,27 +75,8 @@
                 "node": ">= 14"
             }
         },
-        "deps/steamworks.js/node_modules/@napi-rs/cli": {
-            "version": "2.16.2",
-            "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.16.2.tgz",
-            "integrity": "sha512-U2aZfnr0s9KkXpZlYC0l5WxWCXL7vJUNpCnWMwq3T9GG9rhYAAUM9CTZsi1Z+0iR2LcHbfq9EfMgoqnuTyUjfg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "napi": "scripts/index.js"
-            },
-            "engines": {
-                "node": ">= 10"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            }
-        },
         "deps/steamworks.js/node_modules/@types/node": {
             "version": "18.19.130",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -100,8 +84,6 @@
         },
         "deps/steamworks.js/node_modules/electron": {
             "version": "27.3.11",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-27.3.11.tgz",
-            "integrity": "sha512-E1SiyEoI8iW5LW/MigCr7tJuQe7+0105UjqY7FkmCD12e2O6vtUbQ0j05HaBh2YgvkcEVgvQ2A8suIq5b5m6Gw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -119,8 +101,6 @@
         },
         "deps/steamworks.js/node_modules/typescript": {
             "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -139,6 +119,8 @@
         },
         "node_modules/@bbob/parser": {
             "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.9.0.tgz",
+            "integrity": "sha512-tldSYsMoEclke/B1nqL7+HbYMWZHTKvpbEHRSHuY+sZvS1o7Jpdfjb+KPpwP9wLI3p3r7GPv69/wGy+Xibs9yA==",
             "license": "MIT",
             "dependencies": {
                 "@bbob/plugin-helper": "^2.9.0"
@@ -146,14 +128,20 @@
         },
         "node_modules/@bbob/plugin-helper": {
             "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.9.0.tgz",
+            "integrity": "sha512-idpUcNQ2co6T1oU/7/DG/ZRfipSSkTn9Ozw9f5vaXH7nzV3qhqZnhFVlHTzGGnRlzKlBwWOBzOdWi4Zeqg1c5A==",
             "license": "MIT"
         },
         "node_modules/@canvas/image-data": {
-            "version": "1.0.0",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@canvas/image-data/-/image-data-1.1.0.tgz",
+            "integrity": "sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA==",
             "license": "MIT"
         },
         "node_modules/@develar/schema-utils": {
             "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+            "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -170,6 +158,8 @@
         },
         "node_modules/@doctormckay/stdlib": {
             "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.16.1.tgz",
+            "integrity": "sha512-XhuUOzElz6fnNdt70IYNKqhPAEpGaL4JHOhAvklRh0hAhVPW+/wLxaWT3DWUbaG5Dta5YvIp7+cZK3GhIpAuug==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -177,16 +167,20 @@
         },
         "node_modules/@doctormckay/steam-crypto": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@doctormckay/steam-crypto/-/steam-crypto-1.2.0.tgz",
+            "integrity": "sha512-lsxgLw640gEdZBOXpVIcYWcYD+V+QbtEsMPzRvjmjz2XXKc7QeEMyHL07yOFRmay+cUwO4ObKTJO0dSInEuq5g==",
             "license": "MIT"
         },
         "node_modules/@doctormckay/user-agents": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@doctormckay/user-agents/-/user-agents-1.0.0.tgz",
+            "integrity": "sha512-F+sL1YmebZTY2CnjoR9BXFEULpq7y8dxyLx48LZVa0BSDseXdLG/DtPISfM1iNv1XKCeiBzVNfAT/MOQ69v1Zw==",
             "license": "MIT"
         },
         "node_modules/@electron/asar": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.3.1.tgz",
-            "integrity": "sha512-WtpC/+34p0skWZiarRjLAyqaAX78DofhDxnREy/V5XHfu1XEXbFCSSMcDQ6hNCPJFaPy8/NnUgYuf9uiCkvKPg==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+            "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
             "license": "MIT",
             "dependencies": {
                 "commander": "^5.0.0",
@@ -200,18 +194,10 @@
                 "node": ">=10.12.0"
             }
         },
-        "node_modules/@electron/asar/node_modules/minimatch": {
-            "version": "3.1.2",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/@electron/get": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+            "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -232,6 +218,8 @@
         },
         "node_modules/@electron/get/node_modules/fs-extra": {
             "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -245,22 +233,18 @@
         },
         "node_modules/@electron/get/node_modules/jsonfile": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
             "license": "MIT",
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
         },
-        "node_modules/@electron/get/node_modules/semver": {
-            "version": "6.3.1",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@electron/get/node_modules/universalify": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -269,6 +253,8 @@
         },
         "node_modules/@electron/notarize": {
             "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.2.1.tgz",
+            "integrity": "sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -282,6 +268,8 @@
         },
         "node_modules/@electron/notarize/node_modules/fs-extra": {
             "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -296,6 +284,8 @@
         },
         "node_modules/@electron/osx-sign": {
             "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.0.5.tgz",
+            "integrity": "sha512-k9ZzUQtamSoweGQDV2jILiRIHUu7lYlJ3c6IEmjv1hC17rclE+eb9U+f6UFlOOETo0JzY1HNlXy4YOlCvl+Lww==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -316,6 +306,8 @@
         },
         "node_modules/@electron/osx-sign/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -329,6 +321,8 @@
         },
         "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
             "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+            "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -340,6 +334,8 @@
         },
         "node_modules/@electron/universal": {
             "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.5.1.tgz",
+            "integrity": "sha512-kbgXxyEauPJiQQUNG2VgUeyfQNFk6hBF11ISN2PNI6agUgPl55pv4eQmaqHzTAzchBvqZ2tQuRVaPStGf0mxGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -357,6 +353,8 @@
         },
         "node_modules/@electron/universal/node_modules/fs-extra": {
             "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -369,23 +367,16 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@electron/universal/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/@irojs/iro-core": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@irojs/iro-core/-/iro-core-1.2.1.tgz",
+            "integrity": "sha512-p2OvsBSSmidsDsTSkID6jEyXDF7lcyxPrkh3qBzasBZFpjkYd6kZ3yMWai3MlAaQ3F7li/Et7rSJVV09Fpei+A==",
             "license": "MPL-2.0"
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -401,7 +392,9 @@
             }
         },
         "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-            "version": "6.1.0",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -411,8 +404,30 @@
                 "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@isaacs/cliui/node_modules/string-width": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -428,7 +443,9 @@
             }
         },
         "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-            "version": "7.1.0",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -441,8 +458,28 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@jaames/iro": {
             "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/@jaames/iro/-/iro-5.5.2.tgz",
+            "integrity": "sha512-Fbi5U4Vdkw6UsF+R3oMlPONqkvUDMkwzh+mX718gQsDFt3+1r1jvGsrfCbedmXAAy0WsjDHOrefK0BkDk99TQg==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@irojs/iro-core": "^1.2.1",
@@ -451,6 +488,8 @@
         },
         "node_modules/@malept/cross-spawn-promise": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+            "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
             "dev": true,
             "funding": [
                 {
@@ -472,6 +511,8 @@
         },
         "node_modules/@malept/flatpak-bundler": {
             "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+            "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -486,6 +527,8 @@
         },
         "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
             "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -499,9 +542,9 @@
             }
         },
         "node_modules/@napi-rs/cli": {
-            "version": "2.18.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.18.4.tgz",
-            "integrity": "sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.16.2.tgz",
+            "integrity": "sha512-U2aZfnr0s9KkXpZlYC0l5WxWCXL7vJUNpCnWMwq3T9GG9rhYAAUM9CTZsi1Z+0iR2LcHbfq9EfMgoqnuTyUjfg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -517,6 +560,8 @@
         },
         "node_modules/@node-steam/vdf": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@node-steam/vdf/-/vdf-2.2.0.tgz",
+            "integrity": "sha512-YCfIPsIpyrtOP5AdsarjPqjTElVFrXJlWedWNzjCaIeam06v9ebYgApRAcw9b93awNDboTEiHFMnCvlJJHqKcA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
@@ -524,6 +569,8 @@
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -533,6 +580,8 @@
         },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -541,22 +590,32 @@
         },
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/base64": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.1",
@@ -565,28 +624,38 @@
         },
         "node_modules/@protobufjs/float": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/pool": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@retroachievements/api": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-2.4.0.tgz",
-            "integrity": "sha512-e2h/df84O/AgXjmfqZIxFpusCAtTyG4qTlrux72y/SKMuPTYlAyhUQlNGM2ADx2RRo5v+STv+yywcKr0yIghYw==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-2.10.0.tgz",
+            "integrity": "sha512-dLEnjtdhyl8PdKKMa6Itian8eDHNlP8KguY0r6egAQIR/q/8EOLS62cfjhKScMn/y/YwhXCz4+eCEVjYAwBnsg==",
             "license": "MIT",
             "engines": {
                 "node": ">=16"
@@ -594,6 +663,8 @@
         },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -605,6 +676,8 @@
         },
         "node_modules/@szmarczak/http-timer": {
             "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+            "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -616,10 +689,14 @@
         },
         "node_modules/@tokenizer/token": {
             "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "license": "MIT"
         },
         "node_modules/@tootallnate/once": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -628,6 +705,8 @@
         },
         "node_modules/@types/cacheable-request": {
             "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+            "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -639,6 +718,8 @@
         },
         "node_modules/@types/debug": {
             "version": "4.1.12",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -657,7 +738,9 @@
             }
         },
         "node_modules/@types/http-cache-semantics": {
-            "version": "4.0.4",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -673,6 +756,8 @@
         },
         "node_modules/@types/keyv": {
             "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+            "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -681,17 +766,21 @@
         },
         "node_modules/@types/long": {
             "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+            "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
             "license": "MIT"
         },
         "node_modules/@types/ms": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.10.9",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
-            "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+            "version": "25.2.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+            "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
@@ -699,6 +788,8 @@
         },
         "node_modules/@types/plist": {
             "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+            "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -709,6 +800,8 @@
         },
         "node_modules/@types/responselike": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+            "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -716,18 +809,24 @@
             }
         },
         "node_modules/@types/sortablejs": {
-            "version": "1.15.8",
+            "version": "1.15.9",
+            "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
+            "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/verror": {
-            "version": "1.10.10",
+            "version": "1.10.11",
+            "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+            "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
             "dev": true,
             "license": "MIT",
             "optional": true
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -736,7 +835,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.10",
+            "version": "0.8.11",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+            "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -745,11 +846,15 @@
         },
         "node_modules/7zip-bin": {
             "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+            "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/abort-controller": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
             "license": "MIT",
             "dependencies": {
                 "event-target-shim": "^5.0.0"
@@ -760,6 +865,8 @@
         },
         "node_modules/adm-zip": {
             "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+            "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.0"
@@ -767,6 +874,8 @@
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "license": "MIT",
             "dependencies": {
                 "debug": "4"
@@ -794,6 +903,8 @@
         },
         "node_modules/ajv-formats": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -808,9 +919,9 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -831,6 +942,8 @@
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -839,6 +952,8 @@
         },
         "node_modules/ansi-regex": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -846,6 +961,8 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -860,11 +977,15 @@
         },
         "node_modules/app-builder-bin": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
+            "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/app-builder-lib": {
             "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.13.3.tgz",
+            "integrity": "sha512-FAzX6IBit2POXYGnTCT8YHFO/lr5AapAII6zzhQO3Rw4cEDOgK+t1xhLc5tNcKlicTHlo9zxIwnYCX9X2DLkig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -906,26 +1027,28 @@
         },
         "node_modules/app-builder-lib/node_modules/@types/fs-extra": {
             "version": "9.0.13",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+            "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
         },
-        "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
-            "version": "9.2.4",
+        "node_modules/app-builder-lib/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/app-builder-lib/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -937,8 +1060,36 @@
                 "node": ">=12"
             }
         },
+        "node_modules/app-builder-lib/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/app-builder-lib/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/aproba": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "license": "ISC"
         },
         "node_modules/archiver": {
@@ -1020,24 +1171,10 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/archiver/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/are-we-there-yet": {
             "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
             "dependencies": {
@@ -1047,6 +1184,8 @@
         },
         "node_modules/are-we-there-yet/node_modules/readable-stream": {
             "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -1060,10 +1199,14 @@
         },
         "node_modules/are-we-there-yet/node_modules/safe-buffer": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "license": "MIT"
         },
         "node_modules/are-we-there-yet/node_modules/string_decoder": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
@@ -1071,10 +1214,14 @@
         },
         "node_modules/argparse": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
         "node_modules/assert-plus": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1095,11 +1242,15 @@
         },
         "node_modules/async": {
             "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/async-exit-hook": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+            "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1108,11 +1259,15 @@
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/at-least-node": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -1121,6 +1276,8 @@
         },
         "node_modules/atomically": {
             "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+            "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.12.0"
@@ -1128,10 +1285,14 @@
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "funding": [
                 {
                     "type": "github",
@@ -1149,7 +1310,9 @@
             "license": "MIT"
         },
         "node_modules/binarykvparser": {
-            "version": "2.2.0",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binarykvparser/-/binarykvparser-2.3.0.tgz",
+            "integrity": "sha512-B1N5ZxC8I9oSLis7Rg36DxsZJoIikUGU2XwpI0FKFCaPIJIEYi0B9UeIk3QU006axzq0TI9KC3iXelfGGgnWew==",
             "bundleDependencies": [
                 "long"
             ],
@@ -1158,16 +1321,10 @@
                 "long": "^3.2.0"
             }
         },
-        "node_modules/binarykvparser/node_modules/long": {
-            "version": "3.2.0",
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
         "node_modules/bl": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "license": "MIT",
             "dependencies": {
                 "buffer": "^5.5.0",
@@ -1175,8 +1332,52 @@
                 "readable-stream": "^3.4.0"
             }
         },
-        "node_modules/bl/node_modules/buffer": {
+        "node_modules/bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/bluebird-lst": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+            "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bluebird": "^3.5.5"
+            }
+        },
+        "node_modules/bmp-js": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+            "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+            "license": "MIT"
+        },
+        "node_modules/boolean": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/buffer": {
             "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "funding": [
                 {
                     "type": "github",
@@ -1197,76 +1398,10 @@
                 "ieee754": "^1.1.13"
             }
         },
-        "node_modules/bl/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/bluebird": {
-            "version": "3.7.2",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/bluebird-lst": {
-            "version": "1.0.9",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "bluebird": "^3.5.5"
-            }
-        },
-        "node_modules/bmp-js": {
-            "version": "0.1.0",
-            "license": "MIT"
-        },
-        "node_modules/boolean": {
-            "version": "3.2.0",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/buffer": {
-            "version": "6.0.3",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
         "node_modules/buffer-crc32": {
             "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1275,6 +1410,8 @@
         },
         "node_modules/buffer-equal": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+            "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1286,11 +1423,15 @@
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/builder-util": {
             "version": "24.13.1",
+            "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.13.1.tgz",
+            "integrity": "sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1313,18 +1454,9 @@
             }
         },
         "node_modules/builder-util-runtime": {
-            "version": "9.2.10",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/builder-util/node_modules/builder-util-runtime": {
             "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
+            "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1337,6 +1469,8 @@
         },
         "node_modules/builder-util/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1350,6 +1484,8 @@
         },
         "node_modules/bytebuffer": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+            "integrity": "sha512-IuzSdmADppkZ6DlpycMkm8l9zeEq16fWtLvunEwFiYciR/BHo4E8/xs5piFquG+Za8OWmMqHF8zuRviz2LHvRQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "long": "~3"
@@ -1360,6 +1496,8 @@
         },
         "node_modules/cacheable-lookup": {
             "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+            "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1368,6 +1506,8 @@
         },
         "node_modules/cacheable-request": {
             "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+            "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1385,6 +1525,8 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1397,6 +1539,8 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1411,16 +1555,26 @@
             }
         },
         "node_modules/chownr": {
-            "version": "1.1.4",
-            "license": "ISC"
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/chromium-pickle-js": {
             "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+            "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/ci-info": {
             "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
             "dev": true,
             "funding": [
                 {
@@ -1451,68 +1605,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/cli-truncate/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cli-truncate/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/cliui": {
             "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1526,40 +1622,18 @@
         },
         "node_modules/cliui/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/cliui/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1569,24 +1643,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/clone-response": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+            "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1596,16 +1656,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/clone-response/node_modules/mimic-response": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/code-point-at": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -1613,6 +1667,8 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1624,11 +1680,15 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1640,6 +1700,8 @@
         },
         "node_modules/commander": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -1647,6 +1709,8 @@
         },
         "node_modules/compare-version": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+            "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1670,28 +1734,16 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/compress-commons/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
         },
         "node_modules/conf": {
             "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
+            "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.6.3",
@@ -1713,9 +1765,9 @@
             }
         },
         "node_modules/conf/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -1734,8 +1786,22 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT"
         },
+        "node_modules/conf/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/config-file-ts": {
             "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz",
+            "integrity": "sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1757,6 +1823,7 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1776,6 +1843,8 @@
         },
         "node_modules/config-file-ts/node_modules/minimatch": {
             "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1788,16 +1857,32 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/config-file-ts/node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/console-control-strings": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+            "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
             "license": "ISC"
         },
         "node_modules/core-util-is": {
-            "version": "1.0.3",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
             "license": "MIT"
         },
         "node_modules/crc": {
             "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+            "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1819,30 +1904,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/crc/node_modules/buffer": {
-            "version": "5.7.1",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
         "node_modules/crc32-stream": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
@@ -1858,24 +1919,10 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/crc32-stream/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1889,10 +1936,14 @@
         },
         "node_modules/cuint": {
             "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+            "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
             "license": "MIT"
         },
         "node_modules/debounce-fn": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+            "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
             "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^3.0.0"
@@ -1905,7 +1956,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.4.0",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -1921,6 +1974,8 @@
         },
         "node_modules/decode-bmp": {
             "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/decode-bmp/-/decode-bmp-0.2.1.tgz",
+            "integrity": "sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA==",
             "license": "MIT",
             "dependencies": {
                 "@canvas/image-data": "^1.0.0",
@@ -1932,6 +1987,8 @@
         },
         "node_modules/decode-ico": {
             "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/decode-ico/-/decode-ico-0.4.1.tgz",
+            "integrity": "sha512-69NZfbKIzux1vBOd31al3XnMnH+2mqDhEgLdpygErm4d60N+UwA5Sq5WFjmEDQzumgB9fElojGwWG0vybVfFmA==",
             "license": "MIT",
             "dependencies": {
                 "@canvas/image-data": "^1.0.0",
@@ -1943,17 +2000,38 @@
             }
         },
         "node_modules/decompress-response": {
-            "version": "4.2.1",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "mimic-response": "^2.0.0"
+                "mimic-response": "^3.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/decompress-response/node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/deep-extend": {
             "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "license": "MIT",
             "engines": {
                 "node": ">=4.0.0"
@@ -1961,6 +2039,8 @@
         },
         "node_modules/defer-to-connect": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1969,6 +2049,8 @@
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1986,6 +2068,8 @@
         },
         "node_modules/define-properties": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2003,6 +2087,8 @@
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2011,10 +2097,14 @@
         },
         "node_modules/delegates": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
             "license": "MIT"
         },
         "node_modules/detect-libc": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
             "license": "Apache-2.0",
             "bin": {
                 "detect-libc": "bin/detect-libc.js"
@@ -2025,12 +2115,16 @@
         },
         "node_modules/detect-node": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true,
             "license": "MIT",
             "optional": true
         },
         "node_modules/dir-compare": {
             "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
+            "integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2038,19 +2132,10 @@
                 "minimatch": "^3.0.4"
             }
         },
-        "node_modules/dir-compare/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/dmg-builder": {
             "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.13.3.tgz",
+            "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2065,19 +2150,22 @@
                 "dmg-license": "^1.0.11"
             }
         },
-        "node_modules/dmg-builder/node_modules/builder-util-runtime": {
-            "version": "9.2.4",
+        "node_modules/dmg-builder/node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=12"
             }
         },
-        "node_modules/dmg-builder/node_modules/dmg-license": {
+        "node_modules/dmg-license": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
             "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
@@ -2104,21 +2192,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/dmg-builder/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/dot-prop": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+            "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
             "license": "MIT",
             "dependencies": {
                 "is-obj": "^2.0.0"
@@ -2132,6 +2209,8 @@
         },
         "node_modules/dotenv": {
             "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+            "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -2140,11 +2219,15 @@
         },
         "node_modules/dotenv-expand": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+            "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
             "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2158,11 +2241,15 @@
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/ejs": {
             "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -2176,9 +2263,9 @@
             }
         },
         "node_modules/electron": {
-            "version": "35.0.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-35.0.0.tgz",
-            "integrity": "sha512-mwNQNktYLPnUWZVR8iNkfWCBjmM5e2/CmB1rhACwE9ASDbVU7CYPgp/jLUB3bj/LyQsfSuubD82OUite6SN8Uw==",
+            "version": "35.7.5",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-35.7.5.tgz",
+            "integrity": "sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2196,6 +2283,8 @@
         },
         "node_modules/electron-builder": {
             "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.13.3.tgz",
+            "integrity": "sha512-yZSgVHft5dNVlo31qmJAe4BVKQfFdwpRw7sFp1iQglDRCDD6r22zfRJuZlhtB5gp9FHUxCMEoWGq10SkCnMAIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2249,20 +2338,10 @@
                 "node": ">=12"
             }
         },
-        "node_modules/electron-builder/node_modules/builder-util-runtime": {
-            "version": "9.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/electron-builder/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2276,10 +2355,14 @@
         },
         "node_modules/electron-log": {
             "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.8.tgz",
+            "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA==",
             "license": "MIT"
         },
         "node_modules/electron-publish": {
             "version": "24.13.1",
+            "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.13.1.tgz",
+            "integrity": "sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2294,26 +2377,18 @@
         },
         "node_modules/electron-publish/node_modules/@types/fs-extra": {
             "version": "9.0.13",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+            "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
             }
         },
-        "node_modules/electron-publish/node_modules/builder-util-runtime": {
-            "version": "9.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/electron-publish/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2327,6 +2402,8 @@
         },
         "node_modules/electron-store": {
             "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.2.0.tgz",
+            "integrity": "sha512-ukLL5Bevdil6oieAOXz3CMy+OgaItMiVBg701MNlG6W5RaC0AHN7rvlqTCmeb6O7jP0Qa1KKYTE0xV0xbhF4Hw==",
             "license": "MIT",
             "dependencies": {
                 "conf": "^10.2.0",
@@ -2337,21 +2414,38 @@
             }
         },
         "node_modules/electron-updater": {
-            "version": "6.3.9",
+            "version": "6.8.3",
+            "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+            "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
             "license": "MIT",
             "dependencies": {
-                "builder-util-runtime": "9.2.10",
+                "builder-util-runtime": "9.5.1",
                 "fs-extra": "^10.1.0",
                 "js-yaml": "^4.1.0",
                 "lazy-val": "^1.0.5",
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.isequal": "^4.5.0",
-                "semver": "^7.6.3",
+                "semver": "~7.7.3",
                 "tiny-typed-emitter": "^2.1.0"
+            }
+        },
+        "node_modules/electron-updater/node_modules/builder-util-runtime": {
+            "version": "9.5.1",
+            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+            "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.4",
+                "sax": "^1.2.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/electron-updater/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -2362,10 +2456,22 @@
                 "node": ">=12"
             }
         },
+        "node_modules/electron-updater/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/electron/node_modules/@types/node": {
-            "version": "22.19.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
-            "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
+            "version": "22.19.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+            "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2380,12 +2486,15 @@
             "license": "MIT"
         },
         "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "dev": true,
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT"
         },
         "node_modules/end-of-stream": {
-            "version": "1.4.4",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
@@ -2393,6 +2502,8 @@
         },
         "node_modules/env-paths": {
             "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -2400,11 +2511,15 @@
         },
         "node_modules/err-code": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+            "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2413,6 +2528,8 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2421,6 +2538,8 @@
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2432,6 +2551,8 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2446,12 +2567,16 @@
         },
         "node_modules/es6-error": {
             "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
             "dev": true,
             "license": "MIT",
             "optional": true
         },
         "node_modules/escalade": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2460,6 +2585,8 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2472,6 +2599,8 @@
         },
         "node_modules/event-target-shim": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -2479,6 +2608,8 @@
         },
         "node_modules/events": {
             "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.x"
@@ -2486,6 +2617,8 @@
         },
         "node_modules/expand-template": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
             "license": "(MIT OR WTFPL)",
             "engines": {
                 "node": ">=6"
@@ -2493,6 +2626,8 @@
         },
         "node_modules/extract-zip": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2512,6 +2647,8 @@
         },
         "node_modules/extsprintf": {
             "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+            "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
             "dev": true,
             "engines": [
                 "node >=0.6.0"
@@ -2521,17 +2658,21 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
             "funding": [
                 {
                     "type": "github",
@@ -2546,6 +2687,8 @@
         },
         "node_modules/fd-slicer": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2554,6 +2697,8 @@
         },
         "node_modules/file-manager": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-2.0.1.tgz",
+            "integrity": "sha512-y/K/1OCha04OXOxzo3cXJYtIzEk/CUMBb7Okipxueu0u+xCiuoocbwPyh1smUBasOobo4GAYmjgjD9Vh5zI51w==",
             "license": "MIT",
             "dependencies": {
                 "@doctormckay/stdlib": "^1.14.1"
@@ -2564,6 +2709,8 @@
         },
         "node_modules/file-type": {
             "version": "16.5.4",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+            "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
             "license": "MIT",
             "dependencies": {
                 "readable-web-to-node-stream": "^3.0.0",
@@ -2579,14 +2726,41 @@
         },
         "node_modules/filelist": {
             "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+            "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "minimatch": "^5.0.1"
             }
         },
+        "node_modules/filelist/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/filelist/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/find-up": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^3.0.0"
@@ -2596,11 +2770,13 @@
             }
         },
         "node_modules/foreground-child": {
-            "version": "3.3.0",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "cross-spawn": "^7.0.0",
+                "cross-spawn": "^7.0.6",
                 "signal-exit": "^4.0.1"
             },
             "engines": {
@@ -2612,6 +2788,8 @@
         },
         "node_modules/foreground-child/node_modules/signal-exit": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -2622,9 +2800,9 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2640,12 +2818,14 @@
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
             "license": "MIT"
         },
         "node_modules/fs-extra": {
-            "version": "11.3.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-            "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+            "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -2658,6 +2838,8 @@
         },
         "node_modules/fs-minipass": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2669,6 +2851,8 @@
         },
         "node_modules/fs-minipass/node_modules/minipass": {
             "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2680,10 +2864,14 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2692,6 +2880,8 @@
         },
         "node_modules/gauge": {
             "version": "2.7.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+            "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
             "dependencies": {
@@ -2705,8 +2895,36 @@
                 "wide-align": "^1.1.0"
             }
         },
+        "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+            "license": "MIT",
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/gauge/node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+            "license": "MIT",
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -2714,16 +2932,18 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.7",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
+                "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
+                "es-object-atoms": "^1.1.1",
                 "function-bind": "^1.1.2",
-                "get-proto": "^1.0.0",
+                "get-proto": "^1.0.1",
                 "gopd": "^1.2.0",
                 "has-symbols": "^1.1.0",
                 "hasown": "^2.0.2",
@@ -2738,6 +2958,8 @@
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2750,6 +2972,8 @@
         },
         "node_modules/get-stream": {
             "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2764,11 +2988,15 @@
         },
         "node_modules/github-from-package": {
             "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
             "license": "MIT"
         },
         "node_modules/glob": {
             "version": "7.2.3",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -2785,18 +3013,10 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/global-agent": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
@@ -2812,8 +3032,24 @@
                 "node": ">=10.0"
             }
         },
+        "node_modules/global-agent/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "optional": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/globalthis": {
             "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2830,6 +3066,8 @@
         },
         "node_modules/gopd": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2841,6 +3079,8 @@
         },
         "node_modules/got": {
             "version": "11.8.6",
+            "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+            "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2863,37 +3103,16 @@
                 "url": "https://github.com/sindresorhus/got?sponsor=1"
             }
         },
-        "node_modules/got/node_modules/decompress-response": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/got/node_modules/mimic-response": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "license": "ISC"
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2902,6 +3121,8 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -2914,6 +3135,8 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2925,6 +3148,8 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2939,10 +3164,14 @@
         },
         "node_modules/has-unicode": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+            "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
             "license": "ISC"
         },
         "node_modules/hasown": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2954,6 +3183,8 @@
         },
         "node_modules/hosted-git-info": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2964,12 +3195,16 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.1",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/http-proxy-agent": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2983,6 +3218,8 @@
         },
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+            "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2995,6 +3232,8 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3007,6 +3246,8 @@
         },
         "node_modules/icojs": {
             "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/icojs/-/icojs-0.18.0.tgz",
+            "integrity": "sha512-qdG5fGXA+cIQOaUY+xeMT5FgCiS5YW+rp8DZqZIL3AkwRWSSkmvP6DNkQ2+c9WbbWn4aRor+2CDzP9BNRWwnSw==",
             "license": "MIT",
             "dependencies": {
                 "bmp-js": "0.1.0",
@@ -3038,16 +3279,10 @@
                 "node": "^8.11.2 || >=10"
             }
         },
-        "node_modules/iconv-corefoundation/node_modules/node-addon-api": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3059,6 +3294,8 @@
         },
         "node_modules/ieee754": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "funding": [
                 {
                     "type": "github",
@@ -3077,6 +3314,8 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "license": "ISC",
             "dependencies": {
@@ -3086,25 +3325,29 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
         },
         "node_modules/ini": {
             "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "license": "ISC"
         },
         "node_modules/ip-address": {
-            "version": "9.0.5",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
             "license": "MIT",
-            "dependencies": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            },
             "engines": {
                 "node": ">= 12"
             }
         },
         "node_modules/is-ci": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+            "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3115,17 +3358,18 @@
             }
         },
         "node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "license": "MIT",
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=8"
             }
         },
         "node_modules/is-obj": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3133,10 +3377,14 @@
         },
         "node_modules/isarray": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "license": "MIT"
         },
         "node_modules/isbinaryfile": {
-            "version": "5.0.4",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+            "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3148,11 +3396,15 @@
         },
         "node_modules/isexe": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/jackspeak": {
             "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -3166,14 +3418,15 @@
             }
         },
         "node_modules/jake": {
-            "version": "10.9.2",
+            "version": "10.9.4",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+            "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "async": "^3.2.3",
-                "chalk": "^4.0.2",
+                "async": "^3.2.6",
                 "filelist": "^1.0.4",
-                "minimatch": "^3.1.2"
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "jake": "bin/cli.js"
@@ -3182,19 +3435,10 @@
                 "node": ">=10"
             }
         },
-        "node_modules/jake/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/jpeg-js": {
             "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+            "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/js-yaml": {
@@ -3209,12 +3453,10 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsbn": {
-            "version": "1.1.0",
-            "license": "MIT"
-        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3227,16 +3469,22 @@
         },
         "node_modules/json-schema-typed": {
             "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
+            "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
             "license": "BSD-2-Clause"
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "dev": true,
             "license": "ISC",
             "optional": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3247,7 +3495,9 @@
             }
         },
         "node_modules/jsonfile": {
-            "version": "6.1.0",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+            "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
             "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
@@ -3258,6 +3508,8 @@
         },
         "node_modules/keyv": {
             "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3266,6 +3518,8 @@
         },
         "node_modules/kvparser": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/kvparser/-/kvparser-1.0.2.tgz",
+            "integrity": "sha512-5P/5qpTAHjVYWqcI55B3yQwSY2FUrYYrJj5i65V1Wmg7/4W4OnBcaodaEvLyVuugeOnS+BAaKm9LbPazGJcRyA==",
             "license": "MIT",
             "engines": {
                 "node": ">=4.0.0"
@@ -3273,6 +3527,8 @@
         },
         "node_modules/lazy-val": {
             "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+            "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
             "license": "MIT"
         },
         "node_modules/lazystream": {
@@ -3327,6 +3583,8 @@
         },
         "node_modules/locate-path": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^3.0.0",
@@ -3361,6 +3619,8 @@
         },
         "node_modules/lodash.escaperegexp": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
             "license": "MIT"
         },
         "node_modules/lodash.flatten": {
@@ -3373,6 +3633,8 @@
         },
         "node_modules/lodash.isequal": {
             "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
             "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
             "license": "MIT"
         },
@@ -3394,6 +3656,8 @@
         },
         "node_modules/long": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+            "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=0.6"
@@ -3401,6 +3665,8 @@
         },
         "node_modules/lowercase-keys": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3409,6 +3675,8 @@
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3420,6 +3688,8 @@
         },
         "node_modules/lzma": {
             "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/lzma/-/lzma-2.3.2.tgz",
+            "integrity": "sha512-DcfiawQ1avYbW+hsILhF38IKAlnguc/fjHrychs9hdxe4qLykvhT5VTGNs5YRWgaNePh7NTxGD4uv4gKsRomCQ==",
             "license": "MIT",
             "bin": {
                 "lzma.js": "bin/lzma.js"
@@ -3427,6 +3697,8 @@
         },
         "node_modules/matcher": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -3439,6 +3711,8 @@
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3447,6 +3721,8 @@
         },
         "node_modules/mime": {
             "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3458,6 +3734,8 @@
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3466,6 +3744,8 @@
         },
         "node_modules/mime-types": {
             "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3477,59 +3757,58 @@
         },
         "node_modules/mimic-fn": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/mimic-response": {
-            "version": "2.1.0",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=4"
             }
         },
         "node_modules/minimatch": {
-            "version": "5.1.6",
-            "dev": true,
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
+                "node": "*"
             }
         },
         "node_modules/minimist": {
             "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=8"
             }
         },
         "node_modules/minizlib": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3542,6 +3821,8 @@
         },
         "node_modules/minizlib/node_modules/minipass": {
             "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3553,6 +3834,8 @@
         },
         "node_modules/mkdirp": {
             "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3564,18 +3847,26 @@
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
             "license": "MIT"
         },
         "node_modules/node-abi": {
             "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
             "license": "MIT",
             "dependencies": {
                 "semver": "^5.4.1"
@@ -3583,23 +3874,33 @@
         },
         "node_modules/node-abi/node_modules/semver": {
             "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
             }
         },
         "node_modules/node-addon-api": {
-            "version": "3.2.1",
-            "license": "MIT"
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+            "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/node-bignumber": {
             "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/node-bignumber/-/node-bignumber-1.2.2.tgz",
+            "integrity": "sha512-VoTZHmdFQpZH1+q1dz2qcHNCwTWsJg2T3PYwlAyDNFOfVhSYUKQBLFcCpCud+wJBGgCttGavZILaIggDIKqEQQ==",
             "engines": {
                 "node": ">=0.4.0"
             }
         },
         "node_modules/noop-logger": {
             "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+            "integrity": "sha512-6kM8CLXvuW5crTxsAtva2YLrRrDaiTIkIePWs9moLHqbFWT94WpNFjwS/5dfLfECg5i/lkmw3aoqVidxt23TEQ==",
             "license": "MIT"
         },
         "node_modules/normalize-path": {
@@ -3615,6 +3916,8 @@
         },
         "node_modules/normalize-url": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+            "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3626,6 +3929,8 @@
         },
         "node_modules/npmlog": {
             "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "deprecated": "This package is no longer supported.",
             "license": "ISC",
             "dependencies": {
@@ -3637,6 +3942,8 @@
         },
         "node_modules/number-is-nan": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -3644,6 +3951,8 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -3651,6 +3960,8 @@
         },
         "node_modules/object-keys": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -3660,6 +3971,8 @@
         },
         "node_modules/once": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -3667,6 +3980,8 @@
         },
         "node_modules/onetime": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^2.1.0"
@@ -3680,6 +3995,8 @@
         },
         "node_modules/onetime/node_modules/mimic-fn": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -3687,6 +4004,8 @@
         },
         "node_modules/p-cancelable": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+            "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3695,6 +4014,8 @@
         },
         "node_modules/p-limit": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "license": "MIT",
             "dependencies": {
                 "p-try": "^2.0.0"
@@ -3708,6 +4029,8 @@
         },
         "node_modules/p-locate": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^2.0.0"
@@ -3718,6 +4041,8 @@
         },
         "node_modules/p-try": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -3725,11 +4050,15 @@
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
         "node_modules/path-exists": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -3737,6 +4066,8 @@
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -3744,6 +4075,8 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3752,6 +4085,8 @@
         },
         "node_modules/path-scurry": {
             "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -3767,11 +4102,15 @@
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
             "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/peek-readable": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+            "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -3783,11 +4122,15 @@
         },
         "node_modules/pend": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/permessage-deflate": {
             "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.7.tgz",
+            "integrity": "sha512-EUNi/RIsyJ1P1u9QHFwMOUWMYetqlE22ZgGbad7YP856WF4BFF0B7DuNy6vEGsgNNud6c/SkdWzkne71hH8MjA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "*"
@@ -3796,8 +4139,17 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/pkg-up": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+            "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
             "license": "MIT",
             "dependencies": {
                 "find-up": "^3.0.0"
@@ -3808,6 +4160,8 @@
         },
         "node_modules/plist": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+            "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3821,13 +4175,17 @@
         },
         "node_modules/pngjs": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+            "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
             "license": "MIT",
             "engines": {
                 "node": ">=14.19.0"
             }
         },
         "node_modules/preact": {
-            "version": "10.25.4",
+            "version": "10.28.3",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.3.tgz",
+            "integrity": "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -3836,6 +4194,8 @@
         },
         "node_modules/prebuild-install": {
             "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
+            "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
             "license": "MIT",
             "dependencies": {
                 "detect-libc": "^1.0.3",
@@ -3863,6 +4223,8 @@
         },
         "node_modules/process": {
             "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6.0"
@@ -3870,10 +4232,14 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "license": "MIT"
         },
         "node_modules/progress": {
             "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3882,6 +4248,8 @@
         },
         "node_modules/promise-retry": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+            "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3894,6 +4262,8 @@
         },
         "node_modules/protobufjs": {
             "version": "6.11.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+            "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -3918,10 +4288,14 @@
         },
         "node_modules/protobufjs/node_modules/long": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
             "license": "Apache-2.0"
         },
         "node_modules/psl": {
             "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
             "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
@@ -3931,7 +4305,9 @@
             }
         },
         "node_modules/pump": {
-            "version": "3.0.2",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
             "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
@@ -3940,6 +4316,8 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -3947,6 +4325,8 @@
         },
         "node_modules/quick-lru": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3958,6 +4338,8 @@
         },
         "node_modules/rc": {
             "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "dependencies": {
                 "deep-extend": "^0.6.0",
@@ -3971,6 +4353,8 @@
         },
         "node_modules/read-config-file": {
             "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.3.2.tgz",
+            "integrity": "sha512-M80lpCjnE6Wt6zb98DoW8WHR09nzMSpu8XHtPkiTHrJ5Az9CybfeQhTJ8D7saeBHpGhLPIVyA8lcL6ZmdKwY6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3986,21 +4370,23 @@
             }
         },
         "node_modules/readable-stream": {
-            "version": "4.7.0",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "license": "MIT",
             "dependencies": {
-                "abort-controller": "^3.0.0",
-                "buffer": "^6.0.3",
-                "events": "^3.3.0",
-                "process": "^0.11.10",
-                "string_decoder": "^1.3.0"
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": ">= 6"
             }
         },
         "node_modules/readable-web-to-node-stream": {
             "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+            "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
             "license": "MIT",
             "dependencies": {
                 "readable-stream": "^4.7.0"
@@ -4011,6 +4397,46 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/readable-web-to-node-stream/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+            "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/readdir-glob": {
@@ -4024,17 +4450,52 @@
                 "minimatch": "^5.1.0"
             }
         },
+        "node_modules/readdir-glob/node_modules/brace-expansion": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/readdir-glob/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/registry-js": {
-            "version": "1.16.0",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/registry-js/-/registry-js-1.16.1.tgz",
+            "integrity": "sha512-pQ2kD36lh+YNtpaXm6HCCb0QZtV/zQEeKnkfEIj5FDSpF/oFts7pwizEUkWSvP8IbGb4A4a5iBhhS9eUearMmQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "node-addon-api": "^3.1.0",
+                "node-addon-api": "^3.2.1",
                 "prebuild-install": "^5.3.5"
             }
         },
+        "node_modules/registry-js/node_modules/node-addon-api": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+            "license": "MIT"
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4052,11 +4513,15 @@
         },
         "node_modules/resolve-alpn": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/responselike": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+            "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4068,6 +4533,8 @@
         },
         "node_modules/retry": {
             "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4107,6 +4574,7 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
             "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4140,8 +4608,20 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rimraf/node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/roarr": {
             "version": "2.15.4",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
@@ -4159,6 +4639,8 @@
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "funding": [
                 {
                     "type": "github",
@@ -4177,6 +4659,8 @@
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
             "license": "MIT"
         },
@@ -4186,6 +4670,8 @@
         },
         "node_modules/sanitize-filename": {
             "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
             "dev": true,
             "license": "WTFPL OR ISC",
             "dependencies": {
@@ -4193,27 +4679,36 @@
             }
         },
         "node_modules/sax": {
-            "version": "1.4.1",
-            "license": "ISC"
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+            "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
         },
         "node_modules/semver": {
-            "version": "7.7.1",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/semver-compare": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
             "dev": true,
             "license": "MIT",
             "optional": true
         },
         "node_modules/serialize-error": {
             "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -4229,6 +4724,8 @@
         },
         "node_modules/serialize-error/node_modules/type-fest": {
             "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "optional": true,
@@ -4241,10 +4738,14 @@
         },
         "node_modules/set-blocking": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
             "license": "ISC"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4256,6 +4757,8 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4264,10 +4767,14 @@
         },
         "node_modules/signal-exit": {
             "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "license": "ISC"
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
             "funding": [
                 {
                     "type": "github",
@@ -4286,6 +4793,8 @@
         },
         "node_modules/simple-get": {
             "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
             "license": "MIT",
             "dependencies": {
                 "decompress-response": "^4.2.0",
@@ -4293,8 +4802,34 @@
                 "simple-concat": "^1.0.0"
             }
         },
+        "node_modules/simple-get/node_modules/decompress-response": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/simple-get/node_modules/mimic-response": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/simple-update-notifier": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+            "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4304,8 +4839,23 @@
                 "node": ">=10"
             }
         },
+        "node_modules/simple-update-notifier/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/simple-vdf": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/simple-vdf/-/simple-vdf-1.1.1.tgz",
+            "integrity": "sha512-IHz5fiOyWX0etTzlrzpWfKWxkwOhSwbbuZxcig+JuON0id1clnYlINBRbe4M4Pz4VnNvNvNaZiKiS7tdIYyF6g==",
             "license": "MIT"
         },
         "node_modules/slice-ansi": {
@@ -4324,19 +4874,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "license": "MIT",
             "engines": {
                 "node": ">= 6.0.0",
@@ -4344,10 +4885,12 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.4",
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "license": "MIT",
             "dependencies": {
-                "ip-address": "^9.0.5",
+                "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -4357,6 +4900,8 @@
         },
         "node_modules/socks-proxy-agent": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^6.0.2",
@@ -4368,11 +4913,15 @@
             }
         },
         "node_modules/sortablejs": {
-            "version": "1.15.6",
+            "version": "1.15.7",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+            "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
             "license": "MIT"
         },
         "node_modules/source-map": {
             "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -4381,6 +4930,8 @@
         },
         "node_modules/source-map-support": {
             "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4390,10 +4941,16 @@
         },
         "node_modules/sprintf-js": {
             "version": "1.1.3",
-            "license": "BSD-3-Clause"
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "optional": true
         },
         "node_modules/stat-mode": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+            "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4402,6 +4959,8 @@
         },
         "node_modules/steam-appticket": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.2.tgz",
+            "integrity": "sha512-zwDwZALGv3RanE8RHNYcQU3u4Ez23EzMuQ4Lh15uIHddpDh6TI6uFGbC0HNyt6y+UJYSILe77A33VhFZKQiaqQ==",
             "license": "MIT",
             "dependencies": {
                 "@doctormckay/stdlib": "^1.6.0",
@@ -4416,6 +4975,8 @@
         },
         "node_modules/steam-game-path": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/steam-game-path/-/steam-game-path-2.3.0.tgz",
+            "integrity": "sha512-LwKxLonV9rh82KTWFE1gnklfGfZQRWHyU6oN70Sx3CFbHvHlfjjetV9bd3tXuq4b+lwfoRnGZArNQYvxkf11aw==",
             "license": "GPL-3.0",
             "dependencies": {
                 "@node-steam/vdf": "^2.1.0",
@@ -4424,7 +4985,9 @@
             }
         },
         "node_modules/steam-session": {
-            "version": "1.9.2",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/steam-session/-/steam-session-1.9.4.tgz",
+            "integrity": "sha512-MLvg1uMLEOIRHZS5LKruy1w5OqHb8EL7TeMxIY2a4mUcaVOgszz060+jo4c7s3gFeedyuoqGcfwJrR0pLKYzLw==",
             "license": "MIT",
             "dependencies": {
                 "@doctormckay/stdlib": "^2.9.0",
@@ -4444,6 +5007,8 @@
         },
         "node_modules/steam-session/node_modules/@doctormckay/stdlib": {
             "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-2.10.0.tgz",
+            "integrity": "sha512-bwy+gPn6oa2KTpfxJKX3leZoV/wHDVtO0/gq3usPvqPswG//dcf3jVB8LcbRRsKO3BXCt5DqctOQ+Xb07ivxnw==",
             "license": "MIT",
             "dependencies": {
                 "psl": "^1.9.0"
@@ -4453,11 +5018,15 @@
             }
         },
         "node_modules/steam-session/node_modules/long": {
-            "version": "5.3.0",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
             "license": "Apache-2.0"
         },
         "node_modules/steam-session/node_modules/protobufjs": {
-            "version": "7.4.0",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -4480,13 +5049,17 @@
         },
         "node_modules/steam-session/node_modules/steamid": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/steamid/-/steamid-2.1.0.tgz",
+            "integrity": "sha512-ndt1cvuuSC+i8fcxVsmeyRlgGsR1QsoAuIXz+eabj8/Y4GIWE2+mgHA7Hys61JDHOxttfWtXHtN2m5TNYTlORg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
             }
         },
         "node_modules/steam-session/node_modules/websocket13": {
-            "version": "4.0.0",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-4.1.0.tgz",
+            "integrity": "sha512-7+hxkUVTKQlUDTzN2rJI7fJRBXCT6dvRXr1aZflxUZlpNJutHBkKiEIbZOCGs0A1s7vxAmcAXngsNUQMSUTiVQ==",
             "license": "MIT",
             "dependencies": {
                 "@doctormckay/stdlib": "^2.7.1",
@@ -4501,6 +5074,8 @@
         },
         "node_modules/steam-totp": {
             "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-2.1.2.tgz",
+            "integrity": "sha512-bTKlc/NoIUQId+my+O556s55DDsNNXfVIPWFDNVu68beql7AJhV0c+GTjFxfwCDYfdc4NkAme+0WrDdnY2D2VA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -4508,6 +5083,8 @@
         },
         "node_modules/steam-user": {
             "version": "4.29.3",
+            "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.29.3.tgz",
+            "integrity": "sha512-JsLjqXIobWdRq0DoLpDiwDLnBHVkPwl3CG6+NU0nsoT35a0Wd9jbZE+I7pSj9dmk1lLyatzcxneagVrylfDt6g==",
             "license": "MIT",
             "dependencies": {
                 "@bbob/parser": "^2.2.0",
@@ -4533,6 +5110,8 @@
         },
         "node_modules/steamid": {
             "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/steamid/-/steamid-1.1.3.tgz",
+            "integrity": "sha512-t86YjtP1LtPt8D+TaIARm6PtC9tBnF1FhxQeLFs6ohG7vDUfQuy/M8II14rx1TTUkVuYoWHP/7DlvTtoCGULcw==",
             "license": "MIT",
             "dependencies": {
                 "cuint": "^0.2.1"
@@ -4544,26 +5123,32 @@
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/string-width": {
-            "version": "1.0.2",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "license": "MIT",
             "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=8"
             }
         },
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4577,19 +5162,8 @@
         },
         "node_modules/string-width-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4598,7 +5172,30 @@
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -4609,6 +5206,8 @@
         },
         "node_modules/strip-ansi": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^2.0.0"
@@ -4620,6 +5219,8 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4631,6 +5232,8 @@
         },
         "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4639,6 +5242,8 @@
         },
         "node_modules/strip-json-comments": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -4646,6 +5251,8 @@
         },
         "node_modules/strtok3": {
             "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+            "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
             "license": "MIT",
             "dependencies": {
                 "@tokenizer/token": "^0.3.0",
@@ -4661,6 +5268,8 @@
         },
         "node_modules/sumchecker": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+            "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -4672,6 +5281,8 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4683,6 +5294,9 @@
         },
         "node_modules/tar": {
             "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+            "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4709,8 +5323,16 @@
                 "tar-stream": "^2.1.4"
             }
         },
+        "node_modules/tar-fs/node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "license": "ISC"
+        },
         "node_modules/tar-stream": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "license": "MIT",
             "dependencies": {
                 "bl": "^4.0.3",
@@ -4723,36 +5345,10 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tar-stream/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/tar/node_modules/chownr": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/tar/node_modules/minipass": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/temp-file": {
             "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+            "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4762,6 +5358,8 @@
         },
         "node_modules/temp-file/node_modules/fs-extra": {
             "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4775,10 +5373,14 @@
         },
         "node_modules/tiny-typed-emitter": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+            "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
             "license": "MIT"
         },
         "node_modules/tippy.js": {
             "version": "6.3.7",
+            "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+            "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
             "license": "MIT",
             "dependencies": {
                 "@popperjs/core": "^2.9.0"
@@ -4796,6 +5398,8 @@
         },
         "node_modules/tmp-promise": {
             "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+            "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4804,10 +5408,14 @@
         },
         "node_modules/to-data-view": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/to-data-view/-/to-data-view-1.1.0.tgz",
+            "integrity": "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==",
             "license": "MIT"
         },
         "node_modules/token-types": {
             "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+            "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
             "license": "MIT",
             "dependencies": {
                 "@tokenizer/token": "^0.3.0",
@@ -4823,6 +5431,8 @@
         },
         "node_modules/truncate-utf8-bytes": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+            "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
             "dev": true,
             "license": "WTFPL",
             "dependencies": {
@@ -4831,6 +5441,8 @@
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
@@ -4841,6 +5453,8 @@
         },
         "node_modules/type-fest": {
             "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=12.20"
@@ -4850,7 +5464,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.3",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -4869,6 +5485,8 @@
         },
         "node_modules/universalify": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
@@ -4876,6 +5494,8 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -4884,15 +5504,21 @@
         },
         "node_modules/utf8-byte-length": {
             "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
             "dev": true,
             "license": "(WTFPL OR MIT)"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
         },
         "node_modules/verror": {
             "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+            "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -4905,14 +5531,10 @@
                 "node": ">=0.6.0"
             }
         },
-        "node_modules/verror/node_modules/core-util-is": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/websocket-extensions": {
             "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=0.8.0"
@@ -4920,6 +5542,8 @@
         },
         "node_modules/websocket13": {
             "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-3.0.2.tgz",
+            "integrity": "sha512-OgzxBXT9eQ0eEapeK2OKFlgKpegQnjMweHLUwGmfJhm+IbgpZ+NPT2eAEP1UUUjBslbmKpZ47rFU6Dp6agfyGQ==",
             "license": "MIT",
             "dependencies": {
                 "@doctormckay/stdlib": "^1.8.0",
@@ -4934,6 +5558,8 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4948,6 +5574,8 @@
         },
         "node_modules/which-pm-runs": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+            "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
             "license": "MIT",
             "engines": {
                 "node": ">=4"
@@ -4955,22 +5583,26 @@
         },
         "node_modules/wide-align": {
             "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
             "license": "ISC",
             "dependencies": {
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "8.1.0",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -4979,6 +5611,8 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4995,40 +5629,18 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5039,63 +5651,38 @@
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.1.0",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "7.1.0",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
         },
         "node_modules/xmlbuilder": {
             "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5104,6 +5691,8 @@
         },
         "node_modules/y18n": {
             "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -5112,11 +5701,15 @@
         },
         "node_modules/yallist": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/yargs": {
             "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5134,59 +5727,18 @@
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
         },
-        "node_modules/yargs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/yauzl": {
             "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5231,22 +5783,6 @@
             },
             "engines": {
                 "node": ">= 10"
-            }
-        },
-        "node_modules/zip-stream/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         }
     }

--- a/san.d.ts
+++ b/san.d.ts
@@ -53,7 +53,7 @@ declare interface Config {
     nowtrackingpos: "bottomcenter" | "topcenter" | "topleft" | "topright" | "bottomleft" | "bottomright",
     shortcuts: boolean,
     steamss: boolean,
-    screenshots: "off" | "overlay" | "notifyimg",
+    screenshots: "off" | "overlay" | "notifyimg" | "screenshot_only",
     ssmode: "screen" | "window",
     hdrmode: boolean,
     monitor: number,
@@ -594,7 +594,8 @@ declare interface SSWin {
     src: number,
     timer: NodeJS.Timeout | null,
     windowtitle: string | null,
-    haswarned: boolean
+    haswarned: boolean,
+    monitorid?: number
 }
 
 declare module "simple-vdf"

--- a/src/lang/arabic.ts
+++ b/src/lang/arabic.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "مسار اللقطة الشاشة",
                 ssdelay: "تأخير اللقطة الشاشة",
                 notifyimg: "صورة الإشعار",
+                screenshot_only: "لقطة الشاشة الأصلية فقط",
                 imgpath: "مسار الصورة",
                 ssenabled: "تمكين",
                 ssmode: "وضع لقطة الشاشة",

--- a/src/lang/brazilian.ts
+++ b/src/lang/brazilian.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Caminho da Captura de Tela",
                 ssdelay: "Atraso da Captura de Tela",
                 notifyimg: "Imagem de Notificação",
+                screenshot_only: "Apenas Captura Nativa",
                 imgpath: "Caminho da Imagem",
                 ssenabled: "Ativar",
                 ssmode: "Modo Captura de Tela",

--- a/src/lang/bulgarian.ts
+++ b/src/lang/bulgarian.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Път на скрийншота",
                 ssdelay: "Забавяне на скрийншота",
                 notifyimg: "Изображение за известие",
+                screenshot_only: "Само Нативен Скрийншот",
                 imgpath: "Път на изображението",
                 ssenabled: "Активиране",
                 ssmode: "Режим на екранна снимка",

--- a/src/lang/czech.ts
+++ b/src/lang/czech.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Cesta screenshotu",
                 ssdelay: "Zpoždění screenshotu",
                 notifyimg: "Obrázek oznámení",
+                screenshot_only: "Pouze Nativní Snímek",
                 imgpath: "Cesta k obrázku",
                 ssenabled: "Povolit",
                 ssmode: "Režim snímku obrazovky",

--- a/src/lang/danish.ts
+++ b/src/lang/danish.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Screenshot-sti",
                 ssdelay: "Screenshot-forsinkelse",
                 notifyimg: "Notifikationsbillede",
+                screenshot_only: "Kun Native Skærmbillede",
                 imgpath: "Billedsti",
                 ssenabled: "Aktiver",
                 ssmode: "Skærmbilledetilstand",

--- a/src/lang/dutch.ts
+++ b/src/lang/dutch.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Screenshot pad",
                 ssdelay: "Screenshot vertraging",
                 notifyimg: "Meldingsafbeelding",
+                screenshot_only: "Alleen Native Screenshot",
                 imgpath: "Afbeeldingspad",
                 ssenabled: "Inschakelen",
                 ssmode: "Schermafbeeldingmodus",

--- a/src/lang/english.ts
+++ b/src/lang/english.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Screenshot Path",
                 ssdelay: "Screenshot Delay",
                 notifyimg: "Notification Image",
+                screenshot_only: "Native Screenshot Only",
                 imgpath: "Image Path",
                 ssenabled: "Enable",
                 ssmode: "Screenshot Mode",

--- a/src/lang/finnish.ts
+++ b/src/lang/finnish.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Ruutukaappauksen polku",
                 ssdelay: "Ruutukaappauksen viive",
                 notifyimg: "Ilmoituskuva",
+                screenshot_only: "Vain Natiivi Näyttökuva",
                 imgpath: "Kuvan polku",
                 ssenabled: "Ota käyttöön",
                 ssmode: "Näyttökuvatila",

--- a/src/lang/french.ts
+++ b/src/lang/french.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Chemin de la capture d'écran",
                 ssdelay: "Délai de capture d'écran",
                 notifyimg: "Image de notification",
+                screenshot_only: "Capture d'écran native uniquement",
                 imgpath: "Chemin de l'image",
                 ssenabled: "Activer",
                 ssmode: "Mode Capture d’écran",

--- a/src/lang/german.ts
+++ b/src/lang/german.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Screenshot-Pfad",
                 ssdelay: "Screenshot-Verzögerung",
                 notifyimg: "Benachrichtigungsbild",
+                screenshot_only: "Nur Nativer Screenshot",
                 imgpath: "Bildpfad",
                 ssenabled: "Aktivieren",
                 ssmode: "Screenshot-Modus",

--- a/src/lang/greek.ts
+++ b/src/lang/greek.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Διαδρομή στιγμιότυπου",
                 ssdelay: "Καθυστέρηση στιγμιοτύπου",
                 notifyimg: "Εικόνα ειδοποίησης",
+                screenshot_only: "Μόνο Εγγενές Στιγμιότυπο",
                 imgpath: "Διαδρομή εικόνας",
                 ssenabled: "Ενεργοποίηση",
                 ssmode: "Λειτουργία Στιγμιότυπου Οθόνης",

--- a/src/lang/hungarian.ts
+++ b/src/lang/hungarian.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Képernyőkép útvonal",
                 ssdelay: "Képernyőkép késleltetés",
                 notifyimg: "Értesítési kép",
+                screenshot_only: "Csak Natív Képernyőkép",
                 imgpath: "Kép elérési útvonala",
                 ssenabled: "Engedélyezés",
                 ssmode: "Képernyőképfogó mód",

--- a/src/lang/italian.ts
+++ b/src/lang/italian.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Percorso screenshot",
                 ssdelay: "Ritardo screenshot",
                 notifyimg: "Immagine notifica",
+                screenshot_only: "Solo Screenshot Nativo",
                 imgpath: "Percorso dell'immagine",
                 ssenabled: "Abilita",
                 ssmode: "Modalità Schermata",

--- a/src/lang/japanese.ts
+++ b/src/lang/japanese.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "スクリーンショットのパス",
                 ssdelay: "スクリーンショットの遅延",
                 notifyimg: "通知画像",
+                screenshot_only: "ネイティブスクリーンショットのみ",
                 imgpath: "画像のパス",
                 ssenabled: "有効化",
                 ssmode: "スクリーンショットモード",

--- a/src/lang/koreana.ts
+++ b/src/lang/koreana.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "스크린 샷 경로",
                 ssdelay: "스크린 샷 지연",
                 notifyimg: "알림 이미지",
+                screenshot_only: "네이티브 스크린샷만",
                 imgpath: "이미지 경로",
                 ssenabled: "활성화",
                 ssmode: "스크린샷 모드",

--- a/src/lang/norwegian.ts
+++ b/src/lang/norwegian.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Skjermbilde sti",
                 ssdelay: "Skjermbilde forsinkelse",
                 notifyimg: "Varslingsbilde",
+                screenshot_only: "Kun Native Skjermbilde",
                 imgpath: "Bildesti",
                 ssenabled: "Aktiver",
                 ssmode: "Skjermbilde-modus",

--- a/src/lang/polish.ts
+++ b/src/lang/polish.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Ścieżka zrzutu ekranu",
                 ssdelay: "Opóźnienie zrzutu ekranu",
                 notifyimg: "Obrazek powiadomienia",
+                screenshot_only: "Tylko Natywny Zrzut",
                 imgpath: "Ścieżka obrazu",
                 ssenabled: "Włącz",
                 ssmode: "Tryb zrzutu ekranu",

--- a/src/lang/portuguese.ts
+++ b/src/lang/portuguese.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Caminho da Captura de Tela",
                 ssdelay: "Atraso na Captura de Tela",
                 notifyimg: "Imagem de Notificação",
+                screenshot_only: "Apenas Captura Nativa",
                 imgpath: "Caminho da Imagem",
                 ssenabled: "Ativar",
                 ssmode: "Modo de Captura de Tela",

--- a/src/lang/romanian.ts
+++ b/src/lang/romanian.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Cale Captură",
                 ssdelay: "Întârziere Captură",
                 notifyimg: "Imagine Notificare",
+                screenshot_only: "Doar Captură Ecran Nativă",
                 imgpath: "Calea Imaginii",
                 ssenabled: "Activare",
                 ssmode: "Mod Captură Ecran",

--- a/src/lang/russian.ts
+++ b/src/lang/russian.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Путь скриншота",
                 ssdelay: "Задержка скриншота",
                 notifyimg: "Изображение уведомления",
+                screenshot_only: "Только Нативный Скриншот",
                 imgpath: "Путь к изображению",
                 ssenabled: "Включить",
                 ssmode: "Режим скриншота",

--- a/src/lang/schinese.ts
+++ b/src/lang/schinese.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "截图路径",
                 ssdelay: "截图延迟",
                 notifyimg: "通知图片",
+                screenshot_only: "仅原生截图",
                 imgpath: "图片路径",
                 ssenabled: "启用",
                 ssmode: "截图模式",

--- a/src/lang/spanish.ts
+++ b/src/lang/spanish.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Ruta de la captura de pantalla",
                 ssdelay: "Retraso de la captura de pantalla",
                 notifyimg: "Imagen de Notificación",
+                screenshot_only: "Solo Captura Nativa",
                 imgpath: "Ruta de la Imagen",
                 ssenabled: "Habilitar",
                 ssmode: "Modo de Captura de Pantalla",

--- a/src/lang/swedish.ts
+++ b/src/lang/swedish.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Skärmdumpssökväg",
                 ssdelay: "Skärmdumpsfördröjning",
                 notifyimg: "Meddelandebild",
+                screenshot_only: "Endast Nativa Skärmdumpar",
                 imgpath: "Bildsökväg",
                 ssenabled: "Aktivera",
                 ssmode: "Skärmdumpsläge",

--- a/src/lang/tchinese.ts
+++ b/src/lang/tchinese.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "截圖路徑",
                 ssdelay: "截圖延遲",
                 notifyimg: "通知圖片",
+                screenshot_only: "僅原生截圖",
                 imgpath: "圖片路徑",
                 ssenabled: "啟用",
                 ssmode: "截圖模式",

--- a/src/lang/thai.ts
+++ b/src/lang/thai.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "เส้นทางการถ่ายภาพหน้าจอ",
                 ssdelay: "ความล่าช้าในการถ่ายภาพหน้าจอ",
                 notifyimg: "รูปภาพการแจ้งเตือน",
+                screenshot_only: "ภาพหน้าจอพื้นเมืองเท่านั้น",
                 imgpath: "เส้นทางรูปภาพ",
                 ssenabled: "เปิดใช้งาน",
                 ssmode: "โหมดจับภาพหน้าจอ",

--- a/src/lang/turkish.ts
+++ b/src/lang/turkish.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Görüntü Yolu",
                 ssdelay: "Görüntü Gecikmesi",
                 notifyimg: "Bildirim Görseli",
+                screenshot_only: "Yalnızca Yerel Ekran Görüntüsü",
                 imgpath: "Görsel Yolu",
                 ssenabled: "Etkinleştir",
                 ssmode: "Ekran Görüntüsü Modu",

--- a/src/lang/ukrainian.ts
+++ b/src/lang/ukrainian.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Шлях знімка екрана",
                 ssdelay: "Затримка знімка екрана",
                 notifyimg: "Зображення повідомлення",
+                screenshot_only: "Тільки Нативний Знімок",
                 imgpath: "Шлях до зображення",
                 ssenabled: "Увімкнути",
                 ssmode: "Режим знімка екрану",

--- a/src/lang/vietnamese.ts
+++ b/src/lang/vietnamese.ts
@@ -279,6 +279,7 @@ export const translations = {
                 ovpath: "Đường dẫn Chụp Ảnh Màn hình",
                 ssdelay: "Độ Trễ Chụp Ảnh Màn hình",
                 notifyimg: "Hình ảnh thông báo",
+                screenshot_only: "Chỉ Chụp Màn Hình Gốc",
                 imgpath: "Đường dẫn hình ảnh",
                 ssenabled: "Bật",
                 ssmode: "Chế độ Chụp màn hình",


### PR DESCRIPTION
# Pull Request: Native Screenshot Only & Overlay Screenshot Fix

## Summary

This PR adds a new **"Native Screenshot Only"** option under Media → Additional Media, and fixes a bug where **Screenshot with Notification Overlay** could fail to generate output files.

---

## Motivation

This change is intended for users who want to capture the **native Steam achievement notification** together with the **game screen** at the moment of unlock—with no custom overlay or re-rendered notification—so the screenshot is a **faithful, unmodified record** of what appeared on screen (Steam’s own UI + game). The existing “Screenshot with Notification Overlay” uses this app’s custom notification window; “Native Screenshot Only” uses the same delay and capture settings but saves only the raw screen/window capture, preserving the original Steam achievement popup and game scene as seen by the player. To avoid SAN’s own toast appearing in the screenshot, the implementation uses a **screenshot-first** flow: the screen is captured and saved, then the SAN notification and sound are shown.

---

## 1. New feature: Native Screenshot Only

### Behaviour
- New dropdown option: **Additional Media** → **Native Screenshot Only**.
- Uses the same capture pipeline as **Screenshot with Notification Overlay** (Screenshot Delay, Screenshot Mode, Screenshot Source, HDR Mode, Screenshot Path).
- **Screenshot-first flow:** To ensure the screenshot does **not** contain SAN’s own notification UI, the flow is:
  1. On achievement unlock, the notification is **not** added to the display queue.
  2. After the configured **Screenshot Delay**, a single screenshot is taken (screen or window) and saved to the configured **Screenshot Path**—so the capture shows only the game and any native Steam popup.
  3. **After** the screenshot is saved, the SAN notification and sound are shown as usual (same as other modes).
- No overlay window is used for the capture; no notification image is rendered. Only the raw screenshot file is written, then the normal notification + sound flow runs.

### Settings UI
- When **Native Screenshot Only** is selected, the following options are shown and apply:
  - **Screenshot Delay**
  - **Screenshot Mode** (Screen / Window)
  - **Screenshot Source** (monitor list)
  - **HDR Mode**
  - **Screenshot Path**
- Implemented via new `screenshot_only` attribute on the relevant option elements and CSS so they display only when this mode is active. Options that should be hidden by the "Enable" checkbox in overlay/notification-image modes remain visible for `screenshot_only` (e.g. Screenshot Path, Screenshot Delay).

### Code / config changes
- **Type:** `san.d.ts` – `screenshots` type extended with `"screenshot_only"` (Config and Info). `SSWin` interface gains optional `monitorid?: number` so the main process can pass the monitor id back when the screenshot is done.
- **Backend:** `src/app/screenshots.ts` – `configuresrc` handles `screenshot_only` like `overlay` (same delay, monitor/window, HDR, capture flow). For `screenshot_only`, the sswin object stores `monitorid` for the “done” callback. After `capturesrc` completes, the temp file is copied to the final path under `ovpath` without creating the overlay window; then `ipcMain.emit("native_screenshot_done", null, notify, monitorid)` is fired so the main notify flow can run. The previous logic relied on the `src_${notify.id}` IPC event, which is only sent by the overlay window and never fires in `screenshot_only`; that path was replaced with a direct “capture then save” flow plus `native_screenshot_done`.
- **Notify flow:** `src/app/listeners.ts` – For `screenshot_only`, the notification is not pushed to the display queue immediately; it is stored in `pendingScreenshotOnly` (Map by `notify.id`). After `configuresrc` and sending the queue, the handler returns without calling `checkifrunning`, so no SAN window or sound is shown yet. When `ipcMain.on("native_screenshot_done")` runs (after the screenshot is saved), the handler looks up the pending entry, rebuilds `info` via `buildnotify(notify)`, pushes the notification to the queue, sends the updated queue to the renderer, and calls `checkifrunning(info, monitorid)` so the notification and sound are shown. Other modes (off, overlay, notifyimg) are unchanged: they still add to the queue and call `checkifrunning` immediately.
- **UI:** `dist/app/settings.html` – New `<option value="screenshot_only">` in the Additional Media `<select>`; added `screenshot_only` (and where needed `overlay`) to the option wrappers for Screenshot Mode, Screenshot Source, HDR Mode, Screenshot Path, and Screenshot Delay.
- **Styles:** `dist/app/settings.css` – Rules so elements with `[screenshot_only]` are shown when `option[value="screenshot_only"]` is selected; `ssenabled`-based hiding no longer hides the Screenshot Path / Screenshot Delay when the option has `[screenshot_only]`.
- **Translations:** All language files under `src/lang/` – Added `screenshot_only` in `settings.media.content` with appropriate wording (e.g. "Native Screenshot Only" in English).

---

## 2. Bug fix: Screenshot with Notification Overlay not writing files

### Problem
- With **Screenshot with Notification Overlay** enabled, screenshot files were often not generated.
- Cause: **race condition**. `screenshot.configuresrc(notify, monitorid)` was not awaited. The listener `ipcMain.once(notify.id, checkwindowtitle)` and the `setTimeout(capturesrc, delay)` are registered inside `configuresrc`. The renderer sends `notifyready` when the notification window is ready, and the main process then runs `ipcMain.emit(notify.id)`. If `configuresrc` had not finished yet, the listener was not registered, so `emit(notify.id)` did nothing. The overlay path (checkwindowtitle → checksrcimg → createsswin → sscapture) never ran, so the final overlay screenshot was never written.

### Fix
- **File:** `src/app/listeners.ts`
- **Change:** Await `screenshot.configuresrc(notify, monitorid)` before sending the queue, so the listener and the delayed `capturesrc` are always set before the window can send `notifyready` and trigger `emit(notify.id)`.
- **Before:** `preset !== "os" && notify.customisation.ssenabled && screenshot.configuresrc(notify,monitorid)`  
- **After:** `if (preset !== "os" && notify.customisation.ssenabled) await screenshot.configuresrc(notify,monitorid)`

---

## 3. Files touched (overview)

| Area | Files |
|------|--------|
| Types | `san.d.ts` |
| Screenshot logic | `src/app/screenshots.ts` |
| Notify flow | `src/app/listeners.ts` |
| Settings UI | `dist/app/settings.html`, `dist/app/settings.css` |
| Translations | `src/lang/*.ts` (all language files) |

---

## 4. Testing

- **Screenshot with Notification Overlay:** Test notification with overlay + delay; confirm screenshot is written to the configured path after the overlay is shown.
- **Native Screenshot Only:** Test notification with Native Screenshot Only selected; confirm (1) a single screenshot is written to the Screenshot Path after the delay, with **no SAN notification visible in the screenshot** (only game + native Steam popup if any), and (2) the SAN notification and sound appear **after** the screenshot is saved. Verify Screenshot Mode, Screenshot Source, HDR Mode, and Screenshot Path all apply.
- **Other modes:** Quick check that **Off** and **Notification Image** still behave as before.

---

## 5. Notes

- The DevTools console messages about `Autofill.enable` / `Autofill.setAddresses` come from Chromium/Electron’s internal DevTools, not from this PR; they can be ignored.
- For **Screenshot Mode: Window**, “Source is not capturable” can occur on Windows for certain windows (e.g. the app capturing itself); using **Screen** mode or selecting a different window avoids this.
