### PR TITLE
Fix Screenshot Only timing to capture Steam achievement toast

### DIFF
--- a/src/app/listeners.ts
+++ b/src/app/listeners.ts
@@ -512,11 +512,22 @@ export const listeners = {
 
         const cleartemp = () => {
             try {
-                fs.rmSync(sanhelper.temp,{ recursive: true, force: true })
-                fs.mkdirSync(sanhelper.temp)
+                if (fs.existsSync(sanhelper.temp)) {
+                    fs.rmSync(sanhelper.temp,{ recursive: true, force: true })
+                }
+
+                fs.mkdirSync(sanhelper.temp,{ recursive: true })
                 return log.write("INFO",`"${sanhelper.temp}" directory cleared successfully`)
             } catch (err) {
-                return log.write("ERROR",`Error clearing "${sanhelper.temp}" directory: ${err as Error}`)
+                log.write("ERROR",`Error clearing "${sanhelper.temp}" directory: ${err as Error}`)
+
+                // Ensure the directory still exists so HDR/icon writes do not fail with ENOENT
+                try {
+                    fs.mkdirSync(sanhelper.temp,{ recursive: true })
+                    log.write("INFO",`"${sanhelper.temp}" directory recreated after clear failure`)
+                } catch (mkdirerr) {
+                    log.write("ERROR",`Unable to recreate "${sanhelper.temp}": ${mkdirerr as Error}`)
+                }
             }
         }
 
@@ -1190,6 +1201,10 @@ export const listeners = {
         })
 
         const queue: WinType[] = []
+        // Screenshot Only: hold the notification until the screen capture finishes so Steam's achievement toast can still be in frame
+        const pendingScreenshotOnly = new Map<number,{ wintypeobj: WinType, prep: Promise<void> }>()
+        const earlyCaptureStarted = new Set<number>()
+        const earlyCaptureFinished = new Map<number,number | undefined>()
         const runningmap = new Map<number,BrowserWindow | Notification>()
         const posmap = new Map<"topleft" | "topcenter" | "topright" | "bottomleft" | "bottomcenter" | "bottomright",{ y: number, items: { id: number, win: BrowserWindow, bounds: { width: number, height: number, x: number, y: number }, type: NotifyType }[] }>()
 
@@ -1234,6 +1249,9 @@ export const listeners = {
             config.get("notifymax") > 1 && (notify.customisation = { ...notify.customisation, scale: config.get("customisation.main.scale") as number })
 
             const { preset } = notify.customisation
+            const deferssonly = !iswebview && config.get("screenshots") === "ssonly" && notify.customisation.ssenabled && preset !== "os"
+            let resolveprep = () => {}
+            const prep = deferssonly ? new Promise<void>(resolve => { resolveprep = resolve }) : Promise.resolve()
 
             if (!iswebview) {
                 const wintypeobj = preset === "os" ? {
@@ -1270,78 +1288,166 @@ export const listeners = {
                     } as BrowserWindowConstructorOptions
                 }
 
-                queue.push({ ...wintypeobj, order: queue.length } as WinType)
+                // Screenshot Only: delay queueing until after the screen capture is saved
+                if (deferssonly) {
+                    pendingScreenshotOnly.set(notify.id,{ wintypeobj: { ...wintypeobj, order: 0 } as WinType, prep })
+                    // Safety: never leave the SAN toast hanging if capture stalls
+                    setTimeout(() => {
+                        if (!pendingScreenshotOnly.has(notify.id)) return
+                        log.write("WARN",`Screenshot Only capture timed out for id ${notify.id} - showing notification anyway`)
+                        ipcMain.emit("ssonly_screenshot_done",null,notify,monitorid)
+                    },10000)
+                } else {
+                    queue.push({ ...wintypeobj, order: queue.length } as WinType)
                 
-                // Sort "plat" notifications to always display last
-                queue.sort((a,b) => {
-                    if (a.notify.type === "plat" && b.notify.type !== "plat") return 1   // "plat" after "main"/"semi"/"rare"
-                    if (a.notify.type !== "plat" && b.notify.type === "plat") return -1  // "main"/"semi"/"rare" before "plat"
-                    
-                    return a.order - b.order // Otherwise, preserve original order
-                }).forEach((obj,i) => obj.order = i) // Normalise to sequential order
+                    // Sort "plat" notifications to always display last
+                    queue.sort((a,b) => {
+                        if (a.notify.type === "plat" && b.notify.type !== "plat") return 1   // "plat" after "main"/"semi"/"rare"
+                        if (a.notify.type !== "plat" && b.notify.type === "plat") return -1  // "main"/"semi"/"rare" before "plat"
+                        
+                        return a.order - b.order // Otherwise, preserve original order
+                    }).forEach((obj,i) => obj.order = i) // Normalise to sequential order
 
-                // Safeguard to prevent duplicate `order` IDs if found
-                const orders = queue.map(obj => obj.order)
-                const duplicates = orders.some((order,i) => orders.indexOf(order) !== i)
-                
-                if (duplicates) {
-                    log.write("WARN",`Notification queue contains duplicate order IDs - renormalising...`)
-                    queue.forEach((obj,i) => obj.order = i)
+                    // Safeguard to prevent duplicate `order` IDs if found
+                    const orders = queue.map(obj => obj.order)
+                    const duplicates = orders.some((order,i) => orders.indexOf(order) !== i)
+                    
+                    if (duplicates) {
+                        log.write("WARN",`Notification queue contains duplicate order IDs - renormalising...`)
+                        queue.forEach((obj,i) => obj.order = i)
+                    }
                 }
             }
+
+            try {
+                // Screenshot Only: capture should already have started via `earlycapture`.
+                // Fall back here only if the worker did not send it (e.g. test notifications).
+                if (deferssonly && !earlyCaptureStarted.has(notify.id)) {
+                    worker && worker.webContents.send("steam3id")
+                    await new Promise<void>(resolve => setImmediate(resolve))
+                    screenshot.configuresrc(notify,monitorid).catch(err => log.write("ERROR",`configuresrc: ${err as Error}`))
+                }
+
+                earlyCaptureStarted.delete(notify.id)
+
+                const info = await buildnotify(notify)
+
+                const steampath = sanhelper.steampath
+                const __temp = sanhelper.temp
+                const steam3id = notify.steam3id
+                const hqicon = sanhelper.gethqicon(appid)
+
+                if (config.get(`customisation.${notify.type}.bgstyle`) === "gameart" || config.get(`customisation.${notify.type}.usegameicon`)) {
+                    if (notify.ra) {
+                        for (const [key,value] of Object.entries({
+                            icon: notify.gameicon!,
+                            libhero: notify.libhero!,
+                            logo: notify.gameicon!
+                        })) {
+                            gameartobj[key] = value
+                        }
+                    } else {
+                        // Gets all Game Art img files and assigns them to the global "gameartobj" object
+                        for (const [key,value] of Object.entries(await gameart.getall(
+                            { appid, hqicon, steam3id, steampath },
+                            gameartfiles,
+                            __temp,
+                            __root
+                        ))) {
+                            gameartobj[key] = value
+                        }
+                    }
+                }
+                
+                if (iswebview === "customiser") {
+                    const { ssalldetails, screenshots, notify1line } = config.store
+                    const { icon, libhero, logo } = gameartobj
+
+                    return win.webContents.send("customisernotify",{
+                        info,
+                        customisation: notify.customisation,
+                        iswebview,
+                        steampath,
+                        steam3id: notify.steam3id,
+                        hqicon,
+                        temp: sanhelper.temp,
+                        ssalldetails,
+                        screenshots,
+                        gamearticon: icon,
+                        gameartlibhero: libhero,
+                        gameartlogo: logo,
+                        notify1line
+                    } as Info)
+                }
+
+                if (!deferssonly) {
+                    worker && worker.webContents.send("steam3id")
+                    preset !== "os" && notify.customisation.ssenabled && await screenshot.configuresrc(notify,monitorid)
+                }
+
+                win.webContents.send("queue",queue)
+
+                // Screenshot Only: notification + sound wait for `ssonly_screenshot_done`
+                if (deferssonly) {
+                    // Capture may have finished before notify prep completed
+                    if (earlyCaptureFinished.has(notify.id)) {
+                        const finishedmonitorid = earlyCaptureFinished.get(notify.id)
+                        earlyCaptureFinished.delete(notify.id)
+                        ipcMain.emit("ssonly_screenshot_done",null,notify,finishedmonitorid ?? monitorid)
+                    }
+
+                    return
+                }
+
+                checkifrunning(info,monitorid)
+            } finally {
+                resolveprep()
+            }
+        })
+
+        // Fired from the worker as soon as an unlock is detected — starts capture before icon/localisation work
+        ipcMain.on("earlycapture",async (event,notify: Notify,monitorid?: number) => {
+            const config = sanconfig.get()
+            if (config.get("screenshots") !== "ssonly" || !notify.customisation.ssenabled || notify.customisation.preset === "os") return
+            if (earlyCaptureStarted.has(notify.id)) return
+
+            earlyCaptureStarted.add(notify.id)
+            log.write("INFO",`Early Screenshot Only capture started for "${notify.apiname}" (id: ${notify.id})`)
+
+            // Apply the author's Screenshot Delay once, then fire Steam + SAN together
+            const delaysec = config.get("ssdelay")
+            if (delaysec > 0) {
+                log.write("INFO",`Applying Screenshot Delay (${delaysec}s) before Steam/SAN capture...`)
+                await new Promise<void>(resolve => setTimeout(resolve,delaysec * 1000))
+            }
+
+            await takesteamss(notify.steam3id)
+            screenshot.configuresrc(notify,monitorid,{ skipdelay: true }).catch(err => log.write("ERROR",`earlycapture configuresrc: ${err as Error}`))
+        })
+
+        ipcMain.on("ssonly_screenshot_done",async (event,notify: Notify,monitorid?: number) => {
+            const pending = pendingScreenshotOnly.get(notify.id)
+            if (!pending) {
+                // Capture finished before the full notify handler registered pending state
+                earlyCaptureFinished.set(notify.id,monitorid)
+                return
+            }
+
+            pendingScreenshotOnly.delete(notify.id)
+            earlyCaptureFinished.delete(notify.id)
+
+            // Wait for gameart/buildnotify prep that runs in parallel with the capture
+            await pending.prep
 
             const info = await buildnotify(notify)
+            queue.push({ ...pending.wintypeobj, order: queue.length } as WinType)
 
-            const steampath = sanhelper.steampath
-            const __temp = sanhelper.temp
-            const steam3id = notify.steam3id
-            const hqicon = sanhelper.gethqicon(appid)
-
-            if (config.get(`customisation.${notify.type}.bgstyle`) === "gameart" || config.get(`customisation.${notify.type}.usegameicon`)) {
-                if (notify.ra) {
-                    for (const [key,value] of Object.entries({
-                        icon: notify.gameicon!,
-                        libhero: notify.libhero!,
-                        logo: notify.gameicon!
-                    })) {
-                        gameartobj[key] = value
-                    }
-                } else {
-                    // Gets all Game Art img files and assigns them to the global "gameartobj" object
-                    for (const [key,value] of Object.entries(await gameart.getall(
-                        { appid, hqicon, steam3id, steampath },
-                        gameartfiles,
-                        __temp,
-                        __root
-                    ))) {
-                        gameartobj[key] = value
-                    }
-                }
-            }
-            
-            if (iswebview === "customiser") {
-                const { ssalldetails, screenshots, notify1line } = config.store
-                const { icon, libhero, logo } = gameartobj
-
-                return win.webContents.send("customisernotify",{
-                    info,
-                    customisation: notify.customisation,
-                    iswebview,
-                    steampath,
-                    steam3id: notify.steam3id,
-                    hqicon,
-                    temp: sanhelper.temp,
-                    ssalldetails,
-                    screenshots,
-                    gamearticon: icon,
-                    gameartlibhero: libhero,
-                    gameartlogo: logo,
-                    notify1line
-                } as Info)
-            }
-
-            worker && worker.webContents.send("steam3id")
-            preset !== "os" && notify.customisation.ssenabled && await screenshot.configuresrc(notify,monitorid)
+            // Sort "plat" notifications to always display last
+            queue.sort((a,b) => {
+                if (a.notify.type === "plat" && b.notify.type !== "plat") return 1
+                if (a.notify.type !== "plat" && b.notify.type === "plat") return -1
+                return a.order - b.order
+            }).forEach((obj,i) => obj.order = i)
 
             win.webContents.send("queue",queue)
             checkifrunning(info,monitorid)
@@ -1902,8 +2008,7 @@ export const listeners = {
             win.webContents.send("updatelogtype",logtype,filename)
         })
 
-        ipcMain.on("steam3id",async (event,steam3id: number,skipss?: boolean) => {
-            if (skipss) return log.write("INFO",`"skipss" received - skipping screenshot...`)
+        const takesteamss = async (steam3id: number) => {
             if (!sanconfig.get().store.steamss) return log.write("INFO",`"steamss" not active`)
 
             try {
@@ -1916,9 +2021,15 @@ export const listeners = {
                 if (!hotkey) return log.write("WARN",`"${InGameOverlayScreenshotHotKey}" not found in "steamkeycodes" Map`)
 
                 sanhelper.triggerkeypress([hotkey])
+                log.write("INFO",`Steam screenshot hotkey triggered for steam3id ${steam3id}`)
             } catch (err) {
                 log.write("ERROR",`Error triggering Steam screenshot: ${err}`)
             }
+        }
+
+        ipcMain.on("steam3id",async (event,steam3id: number,skipss?: boolean) => {
+            if (skipss) return log.write("INFO",`"skipss" received - skipping screenshot...`)
+            await takesteamss(steam3id)
         })
 
         const listenersvars = {

--- a/src/app/screenshots.ts
+++ b/src/app/screenshots.ts
@@ -72,6 +72,18 @@ export const screenshot = {
         return { monitor: monitor || null, display: display || null }
     },
     srcpath: (id: number) => path.join(sanhelper.temp,`${id}.png`),
+    ensuretemp: () => {
+        if (fs.existsSync(sanhelper.temp)) return true
+
+        try {
+            fs.mkdirSync(sanhelper.temp,{ recursive: true })
+            log.write("INFO",`Created missing temp directory "${sanhelper.temp}"`)
+            return true
+        } catch (err) {
+            log.write("ERROR",`Unable to create temp directory "${sanhelper.temp}": ${err as Error}`)
+            return false
+        }
+    },
     checksrcimg: (notify: Notify,windowtitle: string | null,retries = 0) => {
         const tempimgpath = path.join(sanhelper.temp,`${notify.id}.png`)
         const sswin = sswins.get(notify.id)
@@ -122,18 +134,19 @@ export const screenshot = {
         log.write("INFO",`Building screenshot for "${notify.id}"...`)
         ssmode !== "window" || sswin.windowtitle !== null ? screenshot.checksrcimg(notify,sswin.windowtitle) : log.write("WARN",`Window Title for ID ${notify.id} not found`)
     },
-    configuresrc: async (notify: Notify,monitorid?: number) => {
+    configuresrc: async (notify: Notify,monitorid?: number,opts?: { skipdelay?: boolean }) => {
         try {
             const config = sanconfig.get()
             const screenshots = config.get("screenshots")
             if (screenshots === "off") return
 
-            const sswinsobj = {
+            const sswinsobj: SSWin = {
                 win: null,
                 src: monitorid || -1,
                 timer: null,
                 windowtitle: null,
-                haswarned: false
+                haswarned: false,
+                ...(screenshots === "ssonly" && { monitorid })
             }
 
             if (screenshots === "notifyimg") {
@@ -145,12 +158,14 @@ export const screenshot = {
 
             sswins.has(notify.id) && sswins.delete(notify.id)
 
-            ipcMain.once(`${notify.id}`,() => screenshot.checkwindowtitle(notify.ra ? "screen" : config.get("ssmode"),notify))
+            // Overlay still waits for the notify window before building the composited shot.
+            // Screenshot Only captures on its own (and may run before SAN's toast via earlycapture).
+            if (screenshots === "overlay") ipcMain.once(`${notify.id}`,() => screenshot.checkwindowtitle(notify.ra ? "screen" : config.get("ssmode"),notify))
 
-            const delay = config.get("ssdelay")
+            const delay = opts?.skipdelay ? 0 : config.get("ssdelay")
             const srcpath = screenshot.srcpath(notify.id)
             
-            // Wait to receive global vars from `listeners.ts`
+            // Same listener-var / window-title path as upstream — do not special-case ssmode here
             const [win,worker,appid] = await Promise.all((["win","worker","appid"] as const).map(lv => screenshot.getlistenersvar(lv))) as [BrowserWindow,BrowserWindow,number]
 
             sswins.set(notify.id,sswinsobj)
@@ -158,6 +173,7 @@ export const screenshot = {
             const sswin = sswins.get(notify.id)!
 
             if (worker && config.get("ssmode") === "window" && !notify.ra) {
+                // Replies from worker title cache (instant) — same control flow as upstream
                 sswin.windowtitle = !appid ? win.title : await new Promise(resolve => {
                     ipcMain.once("windowtitles",(event,windowtitles: string[]) => resolve(windowtitles[0]))
                     worker!.webContents.send("windowtitles")
@@ -189,13 +205,58 @@ export const screenshot = {
             sswins.set(notify.id,sswin)
 
             const { monitor } = screenshot.monitor(sswin.src)
-            if (!monitor) return log.write("ERROR",`Error configuring screenshot src: Could not locate monitor with id ${config.get("monitor")}, and no primary fallback found.\n\n${JSON.stringify(config.get("monitors"))}`)
+            if (!monitor) {
+                log.write("ERROR",`Error configuring screenshot src: Could not locate monitor with id ${config.get("monitor")}, and no primary fallback found.\n\n${JSON.stringify(config.get("monitors"))}`)
+
+                if (screenshots === "ssonly") {
+                    const pendingmonitorid = sswins.get(notify.id)?.monitorid ?? monitorid
+                    screenshot.clearsswin(notify.id)
+                    ipcMain.emit("ssonly_screenshot_done",null,notify,pendingmonitorid)
+                }
+
+                return
+            }
 
             const ssmode: "screen" | "window" = !notify.ra && config.get("ssmode") === "window" && sswin.windowtitle ? "window" : "screen"
             log.write("INFO",`Using "${ssmode}" mode for Screenshot (ssmode: "${config.get("ssmode")}" | windowtitle: "${sswin.windowtitle}")`)
 
             const { id, label } = monitor
             let { bounds: { width, height } } = !notify.ra && ssmode === "window" && (["width","height"] as const).every(dim => screenshot.sswinbounds.bounds[dim] !== 0) ? screenshot.sswinbounds : monitor
+
+            if (screenshots === "ssonly") {
+                // Capture pixels, release deferred SAN notify, then save the file (same capture path as upstream)
+                const runssonlycapture = async () => {
+                    let released = false
+                    const release = () => {
+                        if (released) return
+                        released = true
+                        const pendingmonitorid = sswins.get(notify.id)?.monitorid ?? monitorid
+                        ipcMain.emit("ssonly_screenshot_done",null,notify,pendingmonitorid)
+                    }
+
+                    try {
+                        await screenshot.capturesrc({ config, notify: { id: notify.id }, bounds: { width, height }, id, label, monitor, ssmode, srcpath, windowtitle: sswin.windowtitle })
+                        release()
+
+                        if (fs.existsSync(srcpath)) {
+                            await screenshot.createsswin("ssonly",notify)
+                            return
+                        }
+
+                        log.write("WARN",`Screenshot Only capture missing for ID ${notify.id} - notification shown without screenshot file`)
+                        screenshot.clearsswin(notify.id)
+                    } catch (err) {
+                        log.write("ERROR",err as Error)
+                        release()
+                        screenshot.clearsswin(notify.id)
+                    }
+                }
+
+                if (delay > 0) setTimeout(runssonlycapture,delay * 1000)
+                else void runssonlycapture()
+
+                return
+            }
 
             ipcMain.once(`src_${notify.id}`,(event,err) => {
                 if (err) {
@@ -210,6 +271,14 @@ export const screenshot = {
             return
         } catch (err) {
             log.write("ERROR",err as Error)
+
+            if (sanconfig.get().store.screenshots === "ssonly") {
+                const pendingmonitorid = sswins.get(notify.id)?.monitorid ?? monitorid
+                screenshot.clearsswin(notify.id)
+                ipcMain.emit("ssonly_screenshot_done",null,notify,pendingmonitorid)
+                return
+            }
+
             return screenshot.clearsswin(notify.id)
         }
     },
@@ -217,6 +286,8 @@ export const screenshot = {
         const { config, notify, bounds, id, label, monitor, ssmode, srcpath, windowtitle } = ssconfig
         const sswin = sswins.get(notify.id)
         if (!sswin) return log.write("WARN",`"sswin" not found for ID ${notify.id}`)
+
+        if (!screenshot.ensuretemp()) return log.write("ERROR",`Cannot capture screenshot for ID ${notify.id}: temp directory unavailable`)
         
         if (config.get("hdrmode")) {
             let area: number[] | undefined

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -31,6 +31,9 @@ window.localised = new Map<string,LocalisedObj>()
 const pids = new Set<number>()
 let releasetimer: NodeJS.Timeout | null = null
 let processing = false
+let cachedwindowtitles: string[] = []
+let titlecacheinflight = false
+let refreshtitlecache: (() => void) | null = null
 
 const statsobj: StatsObj = {
     appid: 0,
@@ -123,6 +126,9 @@ const worker = {
             clearTimeout(releasetimer)
             releasetimer = null
         }
+
+        cachedwindowtitles = []
+        refreshtitlecache = null
         
         clearInterval(timer)
         log.write("INFO",`Game loop stopped for AppID ${appid}`)
@@ -309,7 +315,39 @@ const startsan = async (appinfo: AppInfo) => {
     
         const processes: ProcessInfo[] = []
 
-        ipcRenderer.on("windowtitles",() => ipcRenderer.send("windowtitles",(usesanwatcher ? Array.from(pids) : processes.map(process => process.pid)).map(pid => client.processes.getWindowTitle(pid))))
+        const gettrackedpids = () => usesanwatcher ? Array.from(pids) : processes.map(process => process.pid)
+
+        refreshtitlecache = () => {
+            if (titlecacheinflight) return
+
+            const tracked = gettrackedpids().filter(pid => pid > 0)
+            if (!tracked.length) {
+                cachedwindowtitles = []
+                return
+            }
+
+            titlecacheinflight = true
+
+            try {
+                cachedwindowtitles = tracked.map(pid => client.processes.getWindowTitle(pid)).filter(Boolean)
+                sanhelper.devmode && log.write("INFO",`Window title cache updated: ${JSON.stringify(cachedwindowtitles)}`)
+            } catch (err) {
+                log.write("WARN",`Unable to refresh window title cache: ${err as Error}`)
+            } finally {
+                titlecacheinflight = false
+            }
+        }
+
+        const starttitlecache = () => {
+            // Warm the cache once after processes are known. Do NOT poll on an interval —
+            // getWindowTitle is sync and can freeze the worker for seconds, blocking steamss + capture IPC.
+            setTimeout(() => refreshtitlecache?.(),0)
+        }
+
+        ipcRenderer.on("windowtitles",() => {
+            // Instant reply only — never call getWindowTitle on this path
+            ipcRenderer.send("windowtitles",cachedwindowtitles)
+        })
         
         ipcRenderer.on("addtosteam",(event,imgpath: string,width: number,height: number) => {
             try {
@@ -344,6 +382,7 @@ const startsan = async (appinfo: AppInfo) => {
             
             ipcRenderer.on("steam3id",(event,skipss?: boolean) => ipcRenderer.send("steam3id",steam3id,skipss))
             ipcRenderer.send("workeractive",true)
+            starttitlecache()
         
             const apinames: string[] = num ? client.achievement.getAchievementNames() : []
             let cache: Achievement[] = num ? cachedata(client,apinames) : []
@@ -395,6 +434,7 @@ const startsan = async (appinfo: AppInfo) => {
                         
                         pids.add(pid)
                         ipcRenderer.send("activeprocesses",appid,true,linkedgame) // Update UI hint on matching process start
+                        setTimeout(() => refreshtitlecache?.(),0)
 
                         return log.write("INFO",worker.creategameinfo(gameinfo,"started"))
                     }
@@ -471,6 +511,30 @@ const startsan = async (appinfo: AppInfo) => {
                             log.write("INFO",`Achievement unlocked: ${JSON.stringify(achievement)}`)
                             
                             const type = achievement.percent <= rarity ? "rare" : (trophymode && (achievement.percent <= semirarity && achievement.percent > rarity) ? "semi" : "main")
+                            const customisation = config.get(`customisation.${type}${themeswitch ? `.usertheme.${themeswitch[1].themes[type]}.customisation` : ""}`) as Customisation
+                            const notifyid = Math.round(Date.now() / Math.random() * 1000)
+
+                            // Fire Screenshot Only capture immediately — before icon/localisation awaits — using cached window titles
+                            if (config.get("screenshots") === "ssonly" && customisation.ssenabled && customisation.preset !== "os") {
+                                const earlynotify: Notify = {
+                                    id: notifyid,
+                                    customisation,
+                                    type,
+                                    gamename: gamename || "???",
+                                    steam3id,
+                                    apiname: achievement.apiname,
+                                    name: achievement.name,
+                                    desc: achievement.desc,
+                                    unlocked: achievement.unlocked,
+                                    hidden: achievement.hidden,
+                                    percent: achievement.percent,
+                                    icon: sanhelper.setfilepath("img","sanlogosquare.svg"),
+                                    gameicon: sanhelper.setfilepath("img","sanlogosquare.svg"),
+                                    unlocktime: new Date(unlocktime).toISOString()
+                                }
+
+                                ipcRenderer.send("earlycapture",earlynotify,themeswitch?.[1].src)
+                            }
                 
                             let retries = 0
                 
@@ -497,7 +561,6 @@ const startsan = async (appinfo: AppInfo) => {
                             const gameiconpath = path.join(sanhelper.temp,"gameicon.png")
                             const gameicon = (config.get(`customisation.${type}.usegameicon`) && fs.existsSync(gameiconpath)) ? gameiconpath : null
                             const localised = await worker.localisedobj(steam3id,achievement)
-                            const customisation = config.get(`customisation.${type}${themeswitch ? `.usertheme.${themeswitch[1].themes[type]}.customisation` : ""}`) as Customisation
                             
                             if (themeswitch) {
                                 log.write("INFO",`Auto-switch entry detected for ${appid}`)
@@ -505,7 +568,7 @@ const startsan = async (appinfo: AppInfo) => {
                             }
                 
                             const notify: Notify = {
-                                id: Math.round(Date.now() / Math.random() * 1000),
+                                id: notifyid,
                                 customisation,
                                 type,
                                 gamename: gamename || "???",

--- a/src/san.d.ts
+++ b/src/san.d.ts
@@ -642,7 +642,9 @@ declare interface SSWin {
     timer: NodeJS.Timeout | null,
     windowtitle: string | null,
     haswarned: boolean,
-    display?: Electron.Display
+    display?: Electron.Display,
+    /** Preserved for Screenshot Only so the deferred notification can reuse the original monitor */
+    monitorid?: number
 }
 
 declare type ExtWins = "ext" | "stat" | "gametimer"


### PR DESCRIPTION
## Problem

When using **Screenshot Only** (`ssonly`), the saved image often does **not** include Steam’s achievement toast.

Users who want “game + Steam achievement notification” cannot rely on **Take Steam Screenshot** (`steamss`): Steam’s screenshot path captures the game framebuffer and does **not** composite the Steam overlay toast. Only a real screen/desktop capture (SAN’s Screenshot Only / HDR path) can include the toast.

On current `master`, Screenshot Only frequently finishes **after** the toast has already disappeared.

This continues the goal of #120 (closed / not merged). This PR is a **new branch from current upstream `master`**, not a reopen of #120.

## Root causes

Two timing problems stacked:

1. **Capture started too late**  
   Screenshot setup ran only after the normal `notify` path had already done slower work (localisation, achievement icon fetch, etc.). By then the Steam toast window was often gone.

2. **Unlock path could block on `getWindowTitle`**  
   With `ssmode: "window"`, capture waited on a synchronous `getWindowTitle` call in the worker. That call can stall for seconds and freeze the worker, which also delayed the Steam screenshot hotkey IPC. Early capture never really started “early”.

`ssdelay` alone could not fix (1)/(2) if capture was still gated behind those slow steps.

## What this PR changes

### Behaviour (Screenshot Only only)

New unlock flow when `screenshots === "ssonly"` and screenshots are enabled for that notify type:

1. Worker detects unlock and immediately sends `earlycapture` (before icon/localisation awaits).
2. Main applies the existing **Screenshot Delay** (`ssdelay`) **once**.
3. Then, together:
   - triggers **Take Steam Screenshot** hotkey (using `notify.steam3id` on the main process — no round-trip to a busy worker)
   - starts SAN Screenshot Only / HDR capture
4. SAN’s own notification is **deferred** until the Screenshot Only file is saved (timeout fallback so notify is not stuck if capture fails).

Overlay / Notification Image / Screenshots Off keep the previous control flow.

### Code changes by file

**`src/app/worker.ts`**
- Background window-title cache (warm on game start / process changes).
- `windowtitles` IPC returns the cache immediately (never sync `getWindowTitle` on the unlock critical path).
- Emits `earlycapture` as soon as an unlock is detected, before icon/localisation work.

**`src/app/listeners.ts`**
- Handles `earlycapture`: wait `ssdelay`, then Steam hotkey + `configuresrc`.
- For `ssonly`, holds the SAN notify in a pending map until capture completes (`ssonly_screenshot_done`), then queues/shows it.
- Steam hotkey helper uses `notify.steam3id` on main (avoids blocked worker).
- Hardens `temp` dir recreate after clear failure; capture timeout fallback so notify still shows.

**`src/app/screenshots.ts`**
- `ssonly` saves the capture itself after `capturesrc` (does not wait for SAN notify-window events).
- `configuresrc(..., { skipdelay: true })` for the early path so delay is not applied twice.
- Ensures `temp` exists before HDR/native write.

**`src/san.d.ts`**
- Optional `monitorid` on `SSWin` so deferred notify can reuse the original monitor.

### Intentionally unchanged

- No new settings UI; still uses the author’s **Screenshot Delay**.
- Does not change Overlay / Notification Image semantics.
- Does not change `ssmode` Window/Screen selection logic (same branches as upstream; titles come from cache).

## Why Steam + SAN fire after the same delay

Previously the Steam hotkey fired immediately while SAN waited on `ssdelay`, so tuning delay felt ineffective and the two shots were desynced.

Now `ssdelay` gates **both**. In testing, **~2s** aligned well with Cyberpunk 2077’s Steam toast; other games may need 1–3s.

## Test plan

- [ ] Media: **Screenshot Only**, enable per-type screenshots, optional **HDR Mode**, optional **Take Steam Screenshot**
- [ ] Set **Screenshot Delay** ≈ **2s** (tune per game)
- [ ] Unlock an achievement:
  - [ ] SAN image includes Steam achievement toast
  - [ ] Steam screenshot still triggers when enabled
  - [ ] SAN notification appears **after** the screenshot
- [ ] Overlay / Notification Image / Off unchanged
- [ ] `ssmode` Window and Screen still work
- [ ] With `ssmode: Window`, unlock no longer stalls for multi-second `getWindowTitle` on the critical path